### PR TITLE
`client.go` fully formalized.

### DIFF
--- a/src/program_proof/session/coq_session.v
+++ b/src/program_proof/session/coq_session.v
@@ -1,7 +1,9 @@
 From Perennial.program_proof.session Require Export session_prelude.
 From Perennial.program_proof.session Require Export definitions.
 
-Module CoqSession.
+Module CoqSessionServer.
+
+  Include Goose.github_com.session.server.
 
   Fixpoint coq_compareVersionVector (v1: list u64) (v2: list u64) : bool :=
     match v1 with
@@ -200,9 +202,9 @@ Module CoqSession.
     | _ => (server, [])
     end.
 
-End CoqSession.
+End CoqSessionServer.
 
-Export CoqSession.
+Export CoqSessionServer.
 
 Section properties.
 

--- a/src/program_proof/session/coq_session.v
+++ b/src/program_proof/session/coq_session.v
@@ -364,9 +364,16 @@ Module INVARIANT.
     ; Id_in_range: (uint.Z s.(Server.Id) >= 0)%Z /\ (uint.nat s.(Server.Id) < length s.(Server.VectorClock))%nat
     }.
 
+  Record CLIENT (c: Client.t) : Prop :=
+    CLIENT_INVARIANT_INTRO
+    { SessionSemantic_ge_0: (uint.Z c.(Client.SessionSemantic) >= 0)%Z
+    ; SessionSemantic_le_5: (uint.Z c.(Client.SessionSemantic) <= 5)%Z
+    }.
+
 End INVARIANT.
 
 Notation SERVER_INVARIANT := INVARIANT.SERVER.
+Notation CLIENT_INVARIANT := INVARIANT.CLIENT.
 
 Section heap.
 

--- a/src/program_proof/session/coq_session_client.v
+++ b/src/program_proof/session/coq_session_client.v
@@ -236,7 +236,7 @@ Section heap.
     {{{
         cv' msgv', RET (client_val cv', message_val msgv');
         is_client cv' (coq_processRequest c requestType serverId value ackMessage).1 n ∗
-        ∃ n', is_message msgv' (coq_processRequest c requestType serverId value ackMessage).2 n n' 0%nat ∗
+        is_message msgv' (coq_processRequest c requestType serverId value ackMessage).2 n (if (uint.Z requestType =? 0) || (uint.Z requestType =? 1) then n else 0%nat) 0%nat ∗
         is_message msgv ackMessage n n n ∗
         ⌜n = uint.nat (coq_processRequest c requestType serverId value ackMessage).1.(Client.NumberOfServers)⌝
     }}}.

--- a/src/program_proof/session/coq_session_client.v
+++ b/src/program_proof/session/coq_session_client.v
@@ -9,6 +9,8 @@ Definition Ca : Z := 5.
 
 Module CoqSessionClient.
 
+  Include Goose.github_com.session.client.
+
   Definition coq_read (c: Client.t) (serverId: u64) : Message.t :=
     match uint.Z c.(Client.SessionSemantic) with
     | 0 => Message.mk 0 (c.(Client.Id)) serverId 0 0 (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
@@ -42,6 +44,396 @@ Module CoqSessionClient.
         else
           (c, Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0)
     end.
+
+  Section heap.
+
+    Context `{hG: !heapGS Σ}.
+
+    Lemma wp_maxTwoInts (x: w64) (y: w64) :
+      {{{
+          True
+      }}}
+        CoqSessionClient.maxTwoInts #x #y 
+      {{{
+          r , RET #r;
+          ⌜r = coq_maxTwoInts x y⌝
+      }}}.
+    Proof.
+      iIntros (Φ) "H H1".
+      rewrite /maxTwoInts. wp_pures.
+      wp_if_destruct.
+      - iModIntro. iApply "H1". iPureIntro.
+        unfold coq_maxTwoInts. apply Z.gtb_lt in Heqb.
+        rewrite Heqb. auto.
+      - iModIntro. iApply "H1". iPureIntro.
+        rewrite /coq_maxTwoInts.
+        assert (uint.Z y >= uint.Z x) by word.
+        assert (uint.Z x >? uint.Z y = false) by word.
+        rewrite H0.
+        auto.
+    Qed.
+
+    Lemma wp_maxTS (x: Slice.t) (xs: list w64) (y: Slice.t) (ys: list w64) (d: dfrac) (d': dfrac) :
+      {{{
+          own_slice_small x uint64T d xs ∗
+          own_slice_small y uint64T d' ys ∗
+          ⌜length xs = length ys⌝
+      }}}
+        CoqSessionClient.maxTS x y 
+      {{{
+          (s': Slice.t), RET slice_val s'; 
+          own_slice s' uint64T (DfracOwn 1) (coq_maxTS xs ys) ∗ 
+          own_slice_small x uint64T d xs ∗
+          own_slice_small y uint64T d' ys 
+      }}}.
+    Proof.
+      iIntros (Φ) "(H & H1 & %H3) H2".
+      rewrite /maxTS.
+      iDestruct (own_slice_small_sz with "H") as %Hsz_x.
+      iDestruct (own_slice_small_sz with "H1") as %Hsz_y.
+      wp_pures. wp_apply wp_ref_to; auto.
+      iIntros (index) "index". wp_pures.
+      wp_pures. wp_apply wp_slice_len.
+      wp_apply wp_ref_to; auto.
+      iIntros (len) "len". wp_pures.
+      wp_bind (NewSlice uint64T (slice.len x)).
+      wp_apply wp_slice_len.
+      wp_apply wp_new_slice; auto.
+      iIntros (s') "s'". 
+      wp_apply wp_ref_to; auto.
+      iIntros (slice) "slice". wp_pures.
+      wp_apply (wp_forBreak_cond
+                  (λ continue, ∃ (i: w64) (l: list w64),
+                      own_slice_small x uint64T d xs ∗
+                      own_slice_small y uint64T d' ys ∗
+                      own_slice s' uint64T (DfracOwn 1) l ∗ 
+                      index ↦[uint64T] #i ∗
+                      len ↦[uint64T] #(length xs) ∗
+                      slice ↦[slice.T uint64T] s' ∗ 
+                      ⌜continue = false -> uint.nat i = (length xs)⌝ ∗
+                      ⌜length l = length xs⌝ ∗
+                      ⌜forall (i': nat),
+                    i' < uint.nat i <= length xs ->
+                    forall (x y: w64), xs !! i' = Some x ->
+                                        ys !! i' = Some y ->
+                                        l !! i' = Some (coq_maxTwoInts x y)⌝ ∗
+                                        ⌜uint.nat i <= length xs⌝ 
+                  )%I
+                with "[] [H H1 index len s' slice]").
+      - iIntros (?). iModIntro. iIntros "H1 H2".
+        iNamed "H1". iDestruct "H1"
+          as "(Hx & Hy & H4 & H5 & H6 & H7 & %H8 & %H9 & %H10 & %H11)".
+        wp_pures. wp_load. wp_load. wp_if_destruct.
+        + wp_pures. wp_load.
+          wp_bind (maxTwoInts _ _)%E.
+          iDestruct "H4" as "[Hs Hsc]".
+          assert (uint.nat i < length xs)%nat by word.
+          rewrite H3 in H. eapply list_lookup_lt in H.
+          destruct H as [x0 H].
+          assert (uint.nat i < length xs)%nat by word.
+          eapply list_lookup_lt in H0.
+          destruct H0 as [y0 H0].
+          wp_apply (wp_SliceGet with "[$Hy]"). { auto. }
+          iIntros "Hy". wp_load. wp_apply (wp_SliceGet with "[$Hx]"). { auto. }
+          iIntros "Hx".
+          wp_apply (wp_maxTwoInts). iIntros (r) "%H12".
+          wp_load. wp_load.
+          wp_apply (wp_SliceSet with "[$Hs]").
+          { iPureIntro. eapply lookup_lt_is_Some_2. word. }
+          iIntros "H11". wp_pures. wp_load. wp_store. iModIntro.
+          iApply "H2". iExists (w64_word_instance.(word.add) i (W64 1)).
+          iExists (<[uint.nat i:=r]> l)%E. iFrame.
+          iSplit. { auto. }
+          iSplit. { iPureIntro. rewrite <- H9. apply length_insert. }
+          iSplit. { iPureIntro. intros. destruct (decide (i' = uint.nat i)).
+                    - rewrite list_lookup_insert_Some.
+                      left.
+                      split. { auto. }
+                      split. { subst. rewrite H4 in H. rewrite H2 in H0. inversion H. inversion H0.
+                              auto. }
+                      word.
+                    - rewrite Z.lt_le_pred in H1.
+                      assert ((Z.pred (uint.nat (w64_word_instance.(word.add) i (W64 1)))) = uint.nat i) by word.
+                      rewrite H5 in H1.
+                      destruct H1. assert(uint.nat i ≠ i') by word.
+                      apply (list_lookup_insert_ne l (uint.nat i) (i') r) in H7.
+                      rewrite H7. eapply H10; try eassumption.
+                      word.
+          }
+          word.
+        + iModIntro. iApply "H2". iExists i. iExists l. iFrame. iPureIntro. split; auto. word.
+      - assert (zero_val uint64T = #(W64 0)). { unfold zero_val. simpl. auto. }
+        rewrite H. iExists (W64 0).
+        iExists (replicate (uint.nat x.(Slice.sz)) (W64 0))%V.
+        iFrame.
+        iSplitL "s'". { rewrite /own_slice. rewrite untype_replicate. iFrame. }
+        iSplitL "len". { rewrite Hsz_x.
+                        assert (#(W64 (uint.nat x.(Slice.sz))) = #x.(Slice.sz)). {
+                          f_equal. rewrite w64_to_nat_id. auto. }
+                        rewrite H0. iFrame. }
+        iPureIntro.
+        split. { intros. inversion H0. }
+        split. { rewrite length_replicate. auto. }
+        split. { intros. word. }
+        word.
+      - iIntros "H". wp_pures. iNamed "H". iDestruct "H" as "(H1 & H3 & H4 & H5 & H6 & H7 & %H8 & %H9 & %H10 & %H11)".
+        wp_load. iModIntro. iApply "H2". iFrame.
+        assert (coq_maxTS xs ys = l). {
+          clear Hsz_x.
+          clear Hsz_y.        
+          generalize dependent ys. generalize dependent l. generalize dependent i.
+          induction xs.
+          + intros. inversion H9. apply nil_length_inv in H0. rewrite H0. auto.
+          + induction ys.
+            * intros. inversion H3.
+            * clear IHys. intros.
+              assert (uint.nat (uint.nat i - 1%nat)%nat = ((uint.nat i) - 1)%nat) by word.
+              destruct (decide (uint.Z a >? uint.Z a0 = true)).
+              { inversion H3.
+                assert (0%nat < uint.nat i <= length (a :: xs)). {
+                  destruct H8; auto. rewrite H3. repeat rewrite length_cons. word. }
+                rewrite /coq_maxTS. rewrite /coq_maxTwoInts.
+                rewrite e.
+                eapply H10 in H0.
+                - rewrite <- head_lookup in H0. rewrite head_Some in H0. destruct H0 as [l' H0].
+                  rewrite H0. f_equal.
+                  + assert (a = coq_maxTwoInts a a0). { rewrite /coq_maxTwoInts. rewrite e. auto. }
+                    eassumption.
+                  + eapply IHxs.
+                    * intros. destruct H8; auto.
+                      rewrite length_cons in H3. assert (uint.nat (uint.nat i - 1)%nat = length xs) by word.
+                      eassumption.
+                    * rewrite H. rewrite length_cons in H11. word.
+                    * rewrite length_cons in H9.
+                      assert (length l = (1 + length l')%nat). { rewrite H0. simpl. auto. }
+                      rewrite H9 in H2. word.
+                    * auto.
+                    * intros. assert (l !! (S i')%nat = l' !! i'). {
+                        rewrite H0. rewrite lookup_cons.
+                        auto. }
+                      rewrite <- H6.
+                      eapply H10.
+                      { rewrite length_cons. word. }
+                      { rewrite lookup_cons_Some. right. split.
+                        - word.
+                        - simpl. replace (i' - 0)%nat with i' by word. eassumption.
+                      }
+                      { rewrite lookup_cons_Some. right. split.
+                        - word.
+                        - simpl. replace (i' - 0)%nat with i' by word. eassumption.
+                      }
+                - auto.
+                - auto.
+              } 
+              assert (uint.Z a >? uint.Z a0 = false) by word.
+              rewrite /coq_maxTS. assert (a0 = coq_maxTwoInts a a0). { rewrite /coq_maxTwoInts. rewrite H0. auto. }
+              rewrite <- H1.
+              assert (0%nat < uint.nat i <= length (a :: xs)). {
+                destruct H8; auto. rewrite H3. repeat rewrite length_cons. word. }
+              eapply H10 in H2.
+              { rewrite <- head_lookup in H2. rewrite head_Some in H2. destruct H2 as [l' H2].
+                rewrite H2. f_equal.
+                - eassumption.
+                - eapply IHxs.
+                  + intros.
+                    inversion H3.
+                    destruct H8; auto.
+                    rewrite length_cons in H3.
+                    assert (uint.nat (uint.nat i - 1)%nat = length xs) by word.
+                    eassumption.
+                  + rewrite H. rewrite length_cons in H11. word.
+                  + rewrite length_cons in H9.
+                    assert (length l = (1 + length l')%nat). {  rewrite H2. simpl. auto. }
+                    rewrite H9 in H4. word.
+                  + auto.
+                  + intros.
+                    assert (l !! (S i')%nat = l' !! i').
+                    { rewrite H2. rewrite lookup_cons.
+                      auto. }
+                    rewrite <- H7.
+                    eapply H10.
+                    * rewrite length_cons. word. 
+                    * rewrite lookup_cons_Some. right. split.
+                      { word. }
+                      { simpl. replace (i' - 0)%nat with i' by word. eassumption. }
+                    * rewrite lookup_cons_Some. right. split.
+                        { word. }
+                        { simpl. replace (i' - 0)%nat with i' by word. eassumption. }
+              }
+          - auto.
+          - auto.
+        }
+        rewrite H. iFrame.
+    Qed.
+
+    Lemma wp_read (c: Client.t) (serverId: u64) (n: nat) cv :
+      {{{
+          is_client cv c n ∗
+          ⌜n = uint.nat c.(Client.NumberOfServers)⌝
+      }}}
+        CoqSessionClient.read (client_val cv) (#serverId)
+      {{{
+          msgv, RET (message_val msgv);
+          is_client cv c n ∗
+          is_message msgv (coq_read c serverId) n n 0%nat
+      }}}.
+    Proof. (**
+      rewrite redefine_client_val redefine_message_val. TypeVector.des cv. iIntros "%Φ (H_is_client & ->) HΦ".
+      iDestruct "H_is_client" as "(%H1 & %H2 & H3 & %H4 & H5 & %H6 & %H7)".
+      simplNotation; simpl; subst; rewrite /CoqSessionClient.read.
+      iPoseProof (own_slice_small_sz with "[$H3]") as "%LENGTH1".
+      iPoseProof (own_slice_small_sz with "[$H5]") as "%LENGTH2".
+      wp_pures. wp_apply wp_ref_to. { repeat econstructor; eauto. } iIntros "%reply H_reply".
+      wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 0))) as [ | ] eqn: Heqb.
+      { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_apply (wp_NewSlice). iIntros "%s1 H_s1".
+        iPoseProof (own_slice_sz with "[$H_s1]") as "%LENGTH3". rewrite length_replicate in LENGTH3.
+        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_load.
+        apply bool_decide_eq_true in Heqb.
+        assert (c .(Client.SessionSemantic) = W64 0) as EQ by congruence.
+        replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 0), (#(W64 0), (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 0, W64 0, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
+        iModIntro. simpl. iApply "HΦ".
+        iSplitL "H3 H5".
+        - iFrame. simplNotation; simpl; done.
+        - unfold coq_read. rewrite -> EQ. replace (uint.Z (W64 0)) with 0%Z by word.
+          unfold is_message; iFrame; simplNotation; simpl.
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
+          iSplitL "". { rewrite length_replicate. done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { iApply own_slice_small_nil; eauto. }
+          iSplitL "". { iPureIntro. word. }
+          done.
+      }
+      wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 1))) as [ | ] eqn: Heqb0.
+      { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_apply (wp_NewSlice). iIntros "%s1 H_s1".
+        iPoseProof (own_slice_sz with "[$H_s1]") as "%LENGTH3". rewrite length_replicate in LENGTH3.
+        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_load.
+        apply bool_decide_eq_true in Heqb0.
+        assert (c .(Client.SessionSemantic) = W64 1) as EQ by congruence.
+        replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 0), (#(W64 0), (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 0, W64 0, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
+        iModIntro. simpl. iApply "HΦ".
+        iSplitL "H3 H5".
+        - iFrame. simplNotation; simpl; done.
+        - unfold coq_read. rewrite -> EQ. replace (uint.Z (W64 1)) with 1%Z by word.
+          unfold is_message; iFrame; simplNotation; simpl.
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
+          iSplitL "". { rewrite length_replicate. done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { iApply own_slice_small_nil; eauto. }
+          iSplitL "". { iPureIntro. word. }
+          done.
+      }
+      wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 2))) as [ | ] eqn: Heqb1.
+      { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_apply (wp_NewSlice). iIntros "%s1 H_s1".
+        iPoseProof (own_slice_sz with "[$H_s1]") as "%LENGTH3". rewrite length_replicate in LENGTH3.
+        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+        wp_pures. wp_load.
+        apply bool_decide_eq_true in Heqb1.
+        assert (c .(Client.SessionSemantic) = W64 2) as EQ by congruence.
+        replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 0), (#(W64 0), (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 0, W64 0, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
+        iModIntro. simpl. iApply "HΦ".
+        iSplitL "H3 H5".
+        - iFrame. simplNotation; simpl; done.
+        - unfold coq_read. rewrite -> EQ. replace (uint.Z (W64 2)) with 2%Z by word.
+          unfold is_message; iFrame; simplNotation; simpl.
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
+          iSplitL "". { rewrite length_replicate. done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { iApply own_slice_small_nil; eauto. }
+          iSplitL "". { iPureIntro. word. }
+          done.
+      }
+      wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 3))) as [ | ] eqn: Heqb2.
+      { admit. }
+      admit.
+    Qed. *) Admitted.
+
+    Lemma wp_write (c: Client.t) (serverId: u64) (value: u64) (n: nat) cv :
+      {{{
+          is_client cv c n ∗
+          ⌜n = uint.nat c.(Client.NumberOfServers)⌝
+      }}}
+        CoqSessionClient.write (client_val cv) (#serverId) (#value)
+      {{{
+          msgv, RET (message_val msgv);
+          is_client cv c n ∗
+          is_message msgv (coq_write c serverId value) n n 0%nat
+      }}}.
+    Proof.
+    Admitted.
+
+    Lemma wp_processRequest (c: Client.t) (requestType: u64) (serverId: u64) (value: u64) (ackMessage: Message.t) (n: nat) cv msgv :
+      {{{
+          is_client cv c n ∗
+          is_message msgv ackMessage n n n ∗
+          ⌜n = uint.nat c.(Client.NumberOfServers)⌝
+      }}}
+        CoqSessionClient.processRequest (client_val cv) (#requestType) (#serverId) (#value) (message_val msgv)
+      {{{
+          cv' msgv', RET (client_val cv', message_val msgv');
+          is_message msgv ackMessage n n n ∗
+          is_client cv' (coq_processRequest c requestType serverId value ackMessage).1 n ∗
+          ∃ n', is_message msgv' (coq_processRequest c requestType serverId value ackMessage).2 n n' 0%nat
+      }}}.
+    Proof.
+    Admitted.
+
+  End heap.
 
 End CoqSessionClient.
 

--- a/src/program_proof/session/coq_session_client.v
+++ b/src/program_proof/session/coq_session_client.v
@@ -324,18 +324,19 @@ Section heap.
         iSplitL "". { iPureIntro. word. }
         done.
     }
-    wp_pures. wp_load. replace (Φ (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0))) by reflexivity.
-    iModIntro. iApply "HΦ".
-    iSplitL "H3 H5".
-    - iFrame. simplNotation; simpl; done.
-    - rewrite -> bool_decide_eq_false in Heqb, Heqb0, Heqb1, Heqb2, Heqb3, Heqb4.
-      assert (c.(Client.SessionSemantic) ≠ (W64 0)) as NE0 by congruence.
-      assert (c.(Client.SessionSemantic) ≠ (W64 1)) as NE1 by congruence.
-      assert (c.(Client.SessionSemantic) ≠ (W64 2)) as NE2 by congruence.
-      assert (c.(Client.SessionSemantic) ≠ (W64 3)) as NE3 by congruence.
-      assert (c.(Client.SessionSemantic) ≠ (W64 4)) as NE4 by congruence.
-      assert (c.(Client.SessionSemantic) ≠ (W64 5)) as NE5 by congruence.
-      unfold coq_read. destruct (uint.nat c .(Client.SessionSemantic)) as [ | [ | [ | [ | [ | [ | n]]]]]] eqn: H_n; try word.
+    { wp_pures. wp_load. replace (Φ (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0))) by reflexivity.
+      iModIntro. iApply "HΦ".
+      iSplitL "H3 H5".
+      - iFrame. simplNotation; simpl; done.
+      - rewrite -> bool_decide_eq_false in Heqb, Heqb0, Heqb1, Heqb2, Heqb3, Heqb4.
+        assert (c.(Client.SessionSemantic) ≠ (W64 0)) as NE0 by congruence.
+        assert (c.(Client.SessionSemantic) ≠ (W64 1)) as NE1 by congruence.
+        assert (c.(Client.SessionSemantic) ≠ (W64 2)) as NE2 by congruence.
+        assert (c.(Client.SessionSemantic) ≠ (W64 3)) as NE3 by congruence.
+        assert (c.(Client.SessionSemantic) ≠ (W64 4)) as NE4 by congruence.
+        assert (c.(Client.SessionSemantic) ≠ (W64 5)) as NE5 by congruence.
+        unfold coq_read. destruct (uint.nat c .(Client.SessionSemantic)) as [ | [ | [ | [ | [ | [ | n]]]]]] eqn: H_n; try word.
+    }
   Qed.
 
   Lemma wp_write (c: Client.t) (serverId: u64) (value: u64) (n: nat) cv :
@@ -583,18 +584,19 @@ Section heap.
         iSplitL "". { iPureIntro. word. }
         done.
     }
-    wp_pures. wp_load. replace (Φ (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0))) by reflexivity.
-    iModIntro. iApply "HΦ".
-    iSplitL "H3 H5".
-    - iFrame. simplNotation; simpl; done.
-    - rewrite -> bool_decide_eq_false in Heqb, Heqb0, Heqb1, Heqb2, Heqb3, Heqb4.
-      assert (c.(Client.SessionSemantic) ≠ (W64 0)) as NE0 by congruence.
-      assert (c.(Client.SessionSemantic) ≠ (W64 1)) as NE1 by congruence.
-      assert (c.(Client.SessionSemantic) ≠ (W64 2)) as NE2 by congruence.
-      assert (c.(Client.SessionSemantic) ≠ (W64 3)) as NE3 by congruence.
-      assert (c.(Client.SessionSemantic) ≠ (W64 4)) as NE4 by congruence.
-      assert (c.(Client.SessionSemantic) ≠ (W64 5)) as NE5 by congruence.
-      unfold coq_read. destruct (uint.nat c .(Client.SessionSemantic)) as [ | [ | [ | [ | [ | [ | n]]]]]] eqn: H_n; try word.
+    { wp_pures. wp_load. replace (Φ (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0))) by reflexivity.
+      iModIntro. iApply "HΦ".
+      iSplitL "H3 H5".
+      - iFrame. simplNotation; simpl; done.
+      - rewrite -> bool_decide_eq_false in Heqb, Heqb0, Heqb1, Heqb2, Heqb3, Heqb4.
+        assert (c.(Client.SessionSemantic) ≠ (W64 0)) as NE0 by congruence.
+        assert (c.(Client.SessionSemantic) ≠ (W64 1)) as NE1 by congruence.
+        assert (c.(Client.SessionSemantic) ≠ (W64 2)) as NE2 by congruence.
+        assert (c.(Client.SessionSemantic) ≠ (W64 3)) as NE3 by congruence.
+        assert (c.(Client.SessionSemantic) ≠ (W64 4)) as NE4 by congruence.
+        assert (c.(Client.SessionSemantic) ≠ (W64 5)) as NE5 by congruence.
+        unfold coq_read. destruct (uint.nat c .(Client.SessionSemantic)) as [ | [ | [ | [ | [ | [ | n]]]]]] eqn: H_n; try word.
+    }
   Qed.
 
   Lemma wp_processRequest (c: Client.t) (requestType: u64) (serverId: u64) (value: u64) (ackMessage: Message.t) (n: nat) cv msgv :
@@ -617,12 +619,15 @@ Section heap.
     simplNotation; simpl; subst; rewrite /CoqSessionClient.processRequest.
     iPoseProof (own_slice_small_sz with "[$H3]") as "%LENGTH1".
     iPoseProof (own_slice_small_sz with "[$H5]") as "%LENGTH2".
+    wp_pures. wp_apply wp_ref_to. { repeat econstructor; eauto. } iIntros "%nc H_nc".
     wp_pures. wp_apply wp_ref_to. { repeat econstructor; eauto. } iIntros "%msg H_msg".
     wp_pures. wp_if_destruct.
     { wp_apply (wp_read c serverId (uint.nat c.(Client.NumberOfServers)) with "[H3 H5]"). { iFrame. simplNotation; simpl; iPureIntro. tauto. } iIntros "%msgv [H_is_client H_msgv]".
       replace (message_val msgv) with (message_into_val.(to_val) msgv) by reflexivity.
       wp_pures; eapply (tac_wp_store_ty _ _ _ _ _ _ []%list); [repeat econstructor; eauto | tc_solve | let l := msg in iAssumptionCore | reflexivity | simpl].
       wp_pures. wp_load.
+      wp_pures. wp_load.
+      replace (#c .(Client.Id), (#c .(Client.NumberOfServers), (t0, (t, (#c .(Client.SessionSemantic), #())))))%V with (client_val (c.(Client.Id), c.(Client.NumberOfServers), t0, t, c.(Client.SessionSemantic))) by reflexivity.
       wp_pures. iModIntro. iApply "HΦ".
       replace (uint.Z (W64 0) =? 0)%Z with true by reflexivity. rewrite orb_true_l.
       iFrame; simplNotation; simpl. iPureIntro; tauto.
@@ -632,6 +637,8 @@ Section heap.
       replace (message_val msgv) with (message_into_val.(to_val) msgv) by reflexivity.
       wp_pures; eapply (tac_wp_store_ty _ _ _ _ _ _ []%list); [repeat econstructor; eauto | tc_solve | let l := msg in iAssumptionCore | reflexivity | simpl].
       wp_pures. wp_load.
+      wp_pures. wp_load.
+      replace (#c .(Client.Id), (#c .(Client.NumberOfServers), (t0, (t, (#c .(Client.SessionSemantic), #())))))%V with (client_val (c.(Client.Id), c.(Client.NumberOfServers), t0, t, c.(Client.SessionSemantic))) by reflexivity.
       wp_pures. iModIntro. iApply "HΦ".
       replace (uint.Z (W64 1) =? 1)%Z with true by reflexivity. rewrite orb_true_r.
       iFrame; simplNotation; simpl. iPureIntro; tauto.
@@ -639,18 +646,134 @@ Section heap.
     wp_pures. wp_if_destruct.
     { wp_pures. wp_if_destruct.
       { wp_apply wp_NewSlice. iIntros "%s1 H_s1". replace (replicate (uint.nat (W64 0)) u64_IntoVal .(IntoVal_def w64)) with ( @nil w64) by reflexivity.
-        admit.
+        wp_pures. wp_apply (wp_SliceAppendSlice with "[H_s1 H27]"). { repeat econstructor; eauto. } { iFrame. } simpl. clear s1. iIntros "%s1 [H_s1 H27]".
+        wp_pures. wp_apply (wp_storeField_struct with "[H_nc]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_nc".
+        wp_pures. rewrite Heqb1. wp_pures.
+        wp_pures. wp_load.
+        wp_pures. wp_load.
+        replace (#c .(Client.Id), (#c .(Client.NumberOfServers), (t0, (s1, (#c .(Client.SessionSemantic), #())))))%V with (client_val (c.(Client.Id), c.(Client.NumberOfServers), t0, s1, c.(Client.SessionSemantic))) by reflexivity.
+        replace (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V with (message_val (W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)) by reflexivity.
+        wp_pures. iModIntro. iApply "HΦ".
+        replace ((uint.Z (W64 2) =? 0) || (uint.Z (W64 2) =? 1)) with false by reflexivity.
+        unfold coq_processRequest.
+        replace (uint.nat (W64 2)) with 2%nat by reflexivity.
+        replace (uint.nat ackMessage .(Message.S2C_Client_OperationType)) with 0%nat by word.
+        simpl.
+        iPoseProof (own_slice_to_small with "[$H_s1]") as "H_s1".
+        iFrame; simplNotation; simpl.
+        iSplitL "". { iPureIntro; tauto. }
+        iSplitR "".
+        { unfold is_message; iFrame; simplNotation; simpl.
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { iApply (own_slice_small_nil); eauto. }
+          iSplitL "". { iPureIntro. word. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { iApply own_slice_small_nil; eauto. }
+          iSplitL "". { iPureIntro. word. }
+          done.
+        }
+        iSplitL "". { iPureIntro; repeat (split; trivial). word. }
+        iPureIntro. destruct H_invariant as [? ?]; split; trivial.
       }
       wp_pures. wp_if_destruct.
       { wp_apply wp_NewSlice. iIntros "%s1 H_s1". replace (replicate (uint.nat (W64 0)) u64_IntoVal .(IntoVal_def w64)) with ( @nil w64) by reflexivity.
-        admit.
+        wp_pures. wp_apply (wp_SliceAppendSlice with "[H_s1 H27]"). { repeat econstructor; eauto. } { iFrame. } simpl. clear s1. iIntros "%s1 [H_s1 H27]".
+        wp_pures. wp_apply (wp_storeField_struct with "[H_nc]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_nc".
+        wp_pures. wp_load.
+        wp_pures. wp_load.
+        replace (#c .(Client.Id), (#c .(Client.NumberOfServers), (s1, (t, (#c .(Client.SessionSemantic), #())))))%V with (client_val (c.(Client.Id), c.(Client.NumberOfServers), s1, t, c.(Client.SessionSemantic))) by reflexivity.
+        replace (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V with (message_val (W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)) by reflexivity.
+        wp_pures. iModIntro. iApply "HΦ".
+        replace ((uint.Z (W64 2) =? 0) || (uint.Z (W64 2) =? 1)) with false by reflexivity.
+        unfold coq_processRequest.
+        replace (uint.nat (W64 2)) with 2%nat by reflexivity.
+        replace (uint.nat ackMessage .(Message.S2C_Client_OperationType)) with 1%nat by word.
+        simpl.
+        iPoseProof (own_slice_to_small with "[$H_s1]") as "H_s1".
+        iFrame; simplNotation; simpl.
+        iSplitL "". { iPureIntro; tauto. }
+        iSplitR "".
+        { unfold is_message; iFrame; simplNotation; simpl.
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { iApply (own_slice_small_nil); eauto. }
+          iSplitL "". { iPureIntro. word. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { iApply own_slice_small_nil; eauto. }
+          iSplitL "". { iPureIntro. word. }
+          done.
+        }
+        iSplitL "". { iPureIntro; repeat (split; trivial). }
+        iPureIntro. destruct H_invariant as [? ?]; split; trivial.
       }
+      { wp_pures. wp_load.
+        wp_pures. wp_load.
+        wp_pures.
+        replace (#c .(Client.Id), (#c .(Client.NumberOfServers), (t0, (t, (#c .(Client.SessionSemantic), #())))))%V with (client_val (c.(Client.Id), c.(Client.NumberOfServers), t0, t, c.(Client.SessionSemantic))) by reflexivity.
+        replace (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V with (message_val (W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)) by reflexivity.
+        iModIntro. iApply "HΦ".
+        replace (uint.Z (W64 2) =? 0)%Z with false by reflexivity. replace (uint.Z (W64 2) =? 1)%Z with false by reflexivity. simpl.
+        unfold coq_processRequest. replace (uint.nat (W64 2)) with 2%nat by word.
+        destruct (uint.nat ackMessage .(Message.S2C_Client_OperationType)) as [ | [ | n]] eqn: H_OBS; try word.
+        iFrame. simplNotation; simpl.
+        iSplitL "". { iPureIntro. tauto. }
+        iSplitR "".
+        { unfold is_message; iFrame; simplNotation; simpl.
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { iApply (own_slice_small_nil); eauto. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { done. }
+          iSplitL "". { iApply own_slice_small_nil; eauto. }
+          iSplitL "". { iPureIntro. word. }
+          done.
+        }
+        iPureIntro; tauto.
+      }
+    }
+    { wp_pures. wp_load.
       wp_pures. wp_load.
-      wp_pures. replace (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V with (message_val (W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)) by reflexivity.
+      wp_pures.
+      replace (#c .(Client.Id), (#c .(Client.NumberOfServers), (t0, (t, (#c .(Client.SessionSemantic), #())))))%V with (client_val (c.(Client.Id), c.(Client.NumberOfServers), t0, t, c.(Client.SessionSemantic))) by reflexivity.
+      replace (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V with (message_val (W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)) by reflexivity.
       iModIntro. iApply "HΦ".
       replace (uint.Z (W64 2) =? 0)%Z with false by reflexivity. replace (uint.Z (W64 2) =? 1)%Z with false by reflexivity. simpl.
-      unfold coq_processRequest. replace (uint.nat (W64 2)) with 2%nat by word.
-      destruct (uint.nat ackMessage .(Message.S2C_Client_OperationType)) as [ | [ | n]] eqn: H_OBS; try word.
+      unfold coq_processRequest. destruct (uint.nat requestType) as [ | [ | [ | n]]] eqn: H_OBS; try word; simpl.
+      replace (uint.Z requestType =? 0)%Z with false by word. replace (uint.Z requestType =? 1)%Z with false by word. simpl.
       iFrame. simplNotation; simpl.
       iSplitL "". { iPureIntro. tauto. }
       iSplitR "".
@@ -677,37 +800,6 @@ Section heap.
       }
       iPureIntro; tauto.
     }
-    wp_pures. wp_load.
-    wp_pures. replace (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V with (message_val (W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)) by reflexivity.
-    iModIntro. iApply "HΦ".
-    replace (uint.Z (W64 2) =? 0)%Z with false by reflexivity. replace (uint.Z (W64 2) =? 1)%Z with false by reflexivity. simpl.
-    unfold coq_processRequest. destruct (uint.nat requestType) as [ | [ | [ | n]]] eqn: H_OBS; try word; simpl.
-    replace (uint.Z requestType =? 0)%Z with false by word. replace (uint.Z requestType =? 1)%Z with false by word. simpl.
-    iFrame. simplNotation; simpl.
-    iSplitL "". { iPureIntro. tauto. }
-    iSplitR "".
-    { unfold is_message; iFrame; simplNotation; simpl.
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { iApply (own_slice_small_nil); eauto. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { iApply own_slice_small_nil; eauto. }
-      iSplitL "". { iPureIntro. word. }
-      done.
-    }
-    iPureIntro; tauto.
-  Admitted.
+  Qed.
 
 End heap.

--- a/src/program_proof/session/coq_session_client.v
+++ b/src/program_proof/session/coq_session_client.v
@@ -1,4 +1,5 @@
 From Perennial.program_proof.session Require Export session_prelude definitions coq_session.
+From Perennial.program_proof.session Require versionVector.
 
 Definition Ev : Z := 0.
 Definition Wfr : Z := 1.
@@ -54,221 +55,24 @@ Section heap.
 
   Context `{hG: !heapGS Σ}.
 
-  Lemma wp_maxTwoInts (x: w64) (y: w64) :
+  Lemma wp_maxTS (x: Slice.t) (xs: list w64) (y: Slice.t) (ys: list w64) (dx: dfrac) (dy: dfrac) :
     {{{
-        True
-    }}}
-      CoqSessionClient.maxTwoInts #x #y 
-    {{{
-        r , RET #r;
-        ⌜r = coq_maxTwoInts x y⌝
-    }}}.
-  Proof.
-    iIntros (Φ) "H H1".
-    rewrite /maxTwoInts. wp_pures.
-    wp_if_destruct.
-    - iModIntro. iApply "H1". iPureIntro.
-      unfold coq_maxTwoInts. apply Z.gtb_lt in Heqb.
-      rewrite Heqb. auto.
-    - iModIntro. iApply "H1". iPureIntro.
-      rewrite /coq_maxTwoInts.
-      assert (uint.Z y >= uint.Z x) by word.
-      assert (uint.Z x >? uint.Z y = false) by word.
-      rewrite H0.
-      auto.
-  Qed.
-
-  Lemma wp_maxTS (x: Slice.t) (xs: list w64) (y: Slice.t) (ys: list w64) (d: dfrac) (d': dfrac) :
-    {{{
-        own_slice_small x uint64T d xs ∗
-        own_slice_small y uint64T d' ys ∗
+        own_slice_small x uint64T dx xs ∗
+        own_slice_small y uint64T dy ys ∗
         ⌜length xs = length ys⌝
     }}}
-      CoqSessionClient.maxTS x y 
+      CoqSessionClient.maxTS (slice_val x) (slice_val y)
     {{{
-        (s': Slice.t), RET slice_val s'; 
-        own_slice s' uint64T (DfracOwn 1) (coq_maxTS xs ys) ∗ 
-        own_slice_small x uint64T d xs ∗
-        own_slice_small y uint64T d' ys 
+        ns, RET (slice_val ns);
+        own_slice_small x uint64T dx xs ∗
+        own_slice_small y uint64T dy ys ∗
+        own_slice ns uint64T (DfracOwn 1) (coq_maxTS xs ys)
     }}}.
   Proof.
-    iIntros (Φ) "(H & H1 & %H3) H2".
-    rewrite /maxTS.
-    iDestruct (own_slice_small_sz with "H") as %Hsz_x.
-    iDestruct (own_slice_small_sz with "H1") as %Hsz_y.
-    wp_pures. wp_apply wp_ref_to; auto.
-    iIntros (index) "index". wp_pures.
-    wp_pures. wp_apply wp_slice_len.
-    wp_apply wp_ref_to; auto.
-    iIntros (len) "len". wp_pures.
-    wp_bind (NewSlice uint64T (slice.len x)).
-    wp_apply wp_slice_len.
-    wp_apply wp_new_slice; auto.
-    iIntros (s') "s'". 
-    wp_apply wp_ref_to; auto.
-    iIntros (slice) "slice". wp_pures.
-    wp_apply (wp_forBreak_cond
-                (λ continue, ∃ (i: w64) (l: list w64),
-                    own_slice_small x uint64T d xs ∗
-                    own_slice_small y uint64T d' ys ∗
-                    own_slice s' uint64T (DfracOwn 1) l ∗ 
-                    index ↦[uint64T] #i ∗
-                    len ↦[uint64T] #(length xs) ∗
-                    slice ↦[slice.T uint64T] s' ∗ 
-                    ⌜continue = false -> uint.nat i = (length xs)⌝ ∗
-                    ⌜length l = length xs⌝ ∗
-                    ⌜forall (i': nat),
-                  i' < uint.nat i <= length xs ->
-                  forall (x y: w64), xs !! i' = Some x ->
-                                      ys !! i' = Some y ->
-                                      l !! i' = Some (coq_maxTwoInts x y)⌝ ∗
-                                      ⌜uint.nat i <= length xs⌝ 
-                )%I
-              with "[] [H H1 index len s' slice]").
-    - iIntros (?). iModIntro. iIntros "H1 H2".
-      iNamed "H1". iDestruct "H1"
-        as "(Hx & Hy & H4 & H5 & H6 & H7 & %H8 & %H9 & %H10 & %H11)".
-      wp_pures. wp_load. wp_load. wp_if_destruct.
-      + wp_pures. wp_load.
-        wp_bind (maxTwoInts _ _)%E.
-        iDestruct "H4" as "[Hs Hsc]".
-        assert (uint.nat i < length xs)%nat by word.
-        rewrite H3 in H. eapply list_lookup_lt in H.
-        destruct H as [x0 H].
-        assert (uint.nat i < length xs)%nat by word.
-        eapply list_lookup_lt in H0.
-        destruct H0 as [y0 H0].
-        wp_apply (wp_SliceGet with "[$Hy]"). { auto. }
-        iIntros "Hy". wp_load. wp_apply (wp_SliceGet with "[$Hx]"). { auto. }
-        iIntros "Hx".
-        wp_apply (wp_maxTwoInts). iIntros (r) "%H12".
-        wp_load. wp_load.
-        wp_apply (wp_SliceSet with "[$Hs]").
-        { iPureIntro. eapply lookup_lt_is_Some_2. word. }
-        iIntros "H11". wp_pures. wp_load. wp_store. iModIntro.
-        iApply "H2". iExists (w64_word_instance.(word.add) i (W64 1)).
-        iExists (<[uint.nat i:=r]> l)%E. iFrame.
-        iSplit. { auto. }
-        iSplit. { iPureIntro. rewrite <- H9. apply length_insert. }
-        iSplit. { iPureIntro. intros. destruct (decide (i' = uint.nat i)).
-                  - rewrite list_lookup_insert_Some.
-                    left.
-                    split. { auto. }
-                    split. { subst. rewrite H4 in H. rewrite H2 in H0. inversion H. inversion H0.
-                            auto. }
-                    word.
-                  - rewrite Z.lt_le_pred in H1.
-                    assert ((Z.pred (uint.nat (w64_word_instance.(word.add) i (W64 1)))) = uint.nat i) by word.
-                    rewrite H5 in H1.
-                    destruct H1. assert(uint.nat i ≠ i') by word.
-                    apply (list_lookup_insert_ne l (uint.nat i) (i') r) in H7.
-                    rewrite H7. eapply H10; try eassumption.
-                    word.
-        }
-        word.
-      + iModIntro. iApply "H2". iExists i. iExists l. iFrame. iPureIntro. split; auto. word.
-    - assert (zero_val uint64T = #(W64 0)). { unfold zero_val. simpl. auto. }
-      rewrite H. iExists (W64 0).
-      iExists (replicate (uint.nat x.(Slice.sz)) (W64 0))%V.
-      iFrame.
-      iSplitL "s'". { rewrite /own_slice. rewrite untype_replicate. iFrame. }
-      iSplitL "len". { rewrite Hsz_x.
-                      assert (#(W64 (uint.nat x.(Slice.sz))) = #x.(Slice.sz)). {
-                        f_equal. rewrite w64_to_nat_id. auto. }
-                      rewrite H0. iFrame. }
-      iPureIntro.
-      split. { intros. inversion H0. }
-      split. { rewrite length_replicate. auto. }
-      split. { intros. word. }
-      word.
-    - iIntros "H". wp_pures. iNamed "H". iDestruct "H" as "(H1 & H3 & H4 & H5 & H6 & H7 & %H8 & %H9 & %H10 & %H11)".
-      wp_load. iModIntro. iApply "H2". iFrame.
-      assert (coq_maxTS xs ys = l). {
-        clear Hsz_x.
-        clear Hsz_y.        
-        generalize dependent ys. generalize dependent l. generalize dependent i.
-        induction xs.
-        + intros. inversion H9. apply nil_length_inv in H0. rewrite H0. auto.
-        + induction ys.
-          * intros. inversion H3.
-          * clear IHys. intros.
-            assert (uint.nat (uint.nat i - 1%nat)%nat = ((uint.nat i) - 1)%nat) by word.
-            destruct (decide (uint.Z a >? uint.Z a0 = true)).
-            { inversion H3.
-              assert (0%nat < uint.nat i <= length (a :: xs)). {
-                destruct H8; auto. rewrite H3. repeat rewrite length_cons. word. }
-              rewrite /coq_maxTS. rewrite /coq_maxTwoInts.
-              rewrite e.
-              eapply H10 in H0.
-              - rewrite <- head_lookup in H0. rewrite head_Some in H0. destruct H0 as [l' H0].
-                rewrite H0. f_equal.
-                + assert (a = coq_maxTwoInts a a0). { rewrite /coq_maxTwoInts. rewrite e. auto. }
-                  eassumption.
-                + eapply IHxs.
-                  * intros. destruct H8; auto.
-                    rewrite length_cons in H3. assert (uint.nat (uint.nat i - 1)%nat = length xs) by word.
-                    eassumption.
-                  * rewrite H. rewrite length_cons in H11. word.
-                  * rewrite length_cons in H9.
-                    assert (length l = (1 + length l')%nat). { rewrite H0. simpl. auto. }
-                    rewrite H9 in H2. word.
-                  * auto.
-                  * intros. assert (l !! (S i')%nat = l' !! i'). {
-                      rewrite H0. rewrite lookup_cons.
-                      auto. }
-                    rewrite <- H6.
-                    eapply H10.
-                    { rewrite length_cons. word. }
-                    { rewrite lookup_cons_Some. right. split.
-                      - word.
-                      - simpl. replace (i' - 0)%nat with i' by word. eassumption.
-                    }
-                    { rewrite lookup_cons_Some. right. split.
-                      - word.
-                      - simpl. replace (i' - 0)%nat with i' by word. eassumption.
-                    }
-              - auto.
-              - auto.
-            } 
-            assert (uint.Z a >? uint.Z a0 = false) by word.
-            rewrite /coq_maxTS. assert (a0 = coq_maxTwoInts a a0). { rewrite /coq_maxTwoInts. rewrite H0. auto. }
-            rewrite <- H1.
-            assert (0%nat < uint.nat i <= length (a :: xs)). {
-              destruct H8; auto. rewrite H3. repeat rewrite length_cons. word. }
-            eapply H10 in H2.
-            { rewrite <- head_lookup in H2. rewrite head_Some in H2. destruct H2 as [l' H2].
-              rewrite H2. f_equal.
-              - eassumption.
-              - eapply IHxs.
-                + intros.
-                  inversion H3.
-                  destruct H8; auto.
-                  rewrite length_cons in H3.
-                  assert (uint.nat (uint.nat i - 1)%nat = length xs) by word.
-                  eassumption.
-                + rewrite H. rewrite length_cons in H11. word.
-                + rewrite length_cons in H9.
-                  assert (length l = (1 + length l')%nat). {  rewrite H2. simpl. auto. }
-                  rewrite H9 in H4. word.
-                + auto.
-                + intros.
-                  assert (l !! (S i')%nat = l' !! i').
-                  { rewrite H2. rewrite lookup_cons.
-                    auto. }
-                  rewrite <- H7.
-                  eapply H10.
-                  * rewrite length_cons. word. 
-                  * rewrite lookup_cons_Some. right. split.
-                    { word. }
-                    { simpl. replace (i' - 0)%nat with i' by word. eassumption. }
-                  * rewrite lookup_cons_Some. right. split.
-                      { word. }
-                      { simpl. replace (i' - 0)%nat with i' by word. eassumption. }
-            }
-        - auto.
-        - auto.
-      }
-      rewrite H. iFrame.
+    replace (maxTS x y) with (CoqSessionServer.maxTS (slice_val x) (slice_val y)) by reflexivity.
+    iIntros "%Φ H_precondition HΦ".
+    wp_apply (versionVector.wp_maxTS with "[$H_precondition]").
+    iIntros "%ns (H_ns & H_xs & H_ys)". iApply "HΦ". iFrame.
   Qed.
 
   Lemma wp_read (c: Client.t) (serverId: u64) (n: nat) cv :

--- a/src/program_proof/session/coq_session_client.v
+++ b/src/program_proof/session/coq_session_client.v
@@ -13,35 +13,35 @@ Module CoqSessionClient.
   Include Goose.github_com.session.client.
 
   Definition coq_read (c: Client.t) (serverId: u64) : Message.t :=
-    match uint.Z c.(Client.SessionSemantic) with
-    | 0 => Message.mk 0 (c.(Client.Id)) serverId 0 0 (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
-    | 1 => Message.mk 0 (c.(Client.Id)) serverId 0 0 (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
-    | 2 => Message.mk 0 (c.(Client.Id)) serverId 0 0 (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
-    | 3 => Message.mk 0 (c.(Client.Id)) serverId 0 0 (c.(Client.ReadVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
-    | 4 => Message.mk 0 (c.(Client.Id)) serverId 0 0 (c.(Client.WriteVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
-    | 5 => Message.mk 0 (c.(Client.Id)) serverId 0 0 (coq_maxTS c.(Client.WriteVersionVector) c.(Client.ReadVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
+    match uint.nat c.(Client.SessionSemantic) with
+    | 0%nat => Message.mk 0 (c.(Client.Id)) serverId 0 0 (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
+    | 1%nat => Message.mk 0 (c.(Client.Id)) serverId 0 0 (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
+    | 2%nat => Message.mk 0 (c.(Client.Id)) serverId 0 0 (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
+    | 3%nat => Message.mk 0 (c.(Client.Id)) serverId 0 0 (c.(Client.ReadVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
+    | 4%nat => Message.mk 0 (c.(Client.Id)) serverId 0 0 (c.(Client.WriteVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
+    | 5%nat => Message.mk 0 (c.(Client.Id)) serverId 0 0 (coq_maxTS c.(Client.WriteVersionVector) c.(Client.ReadVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
     | _ => Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0
     end.
 
   Definition coq_write (c: Client.t) (serverId: u64) (value: u64) : Message.t :=
-    match uint.Z c.(Client.SessionSemantic) with
-    | 0 => Message.mk 0 (c.(Client.Id)) serverId 1 value (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
-    | 1 => Message.mk 0 (c.(Client.Id)) serverId 1 value (c.(Client.ReadVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
-    | 2 => Message.mk 0 (c.(Client.Id)) serverId 1 value (c.(Client.WriteVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
-    | 3 => Message.mk 0 (c.(Client.Id)) serverId 1 value (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
-    | 4 => Message.mk 0 (c.(Client.Id)) serverId 1 value (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
-    | 5 => Message.mk 0 (c.(Client.Id)) serverId 1 value (coq_maxTS c.(Client.WriteVersionVector) c.(Client.ReadVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
+    match uint.nat c.(Client.SessionSemantic) with
+    | 0%nat => Message.mk 0 (c.(Client.Id)) serverId 1 value (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
+    | 1%nat => Message.mk 0 (c.(Client.Id)) serverId 1 value (c.(Client.ReadVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
+    | 2%nat => Message.mk 0 (c.(Client.Id)) serverId 1 value (c.(Client.WriteVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
+    | 3%nat => Message.mk 0 (c.(Client.Id)) serverId 1 value (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
+    | 4%nat => Message.mk 0 (c.(Client.Id)) serverId 1 value (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
+    | 5%nat => Message.mk 0 (c.(Client.Id)) serverId 1 value (coq_maxTS c.(Client.WriteVersionVector) c.(Client.ReadVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
     | _ => Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0
     end.
 
   Definition coq_processRequest (c: Client.t) (requestType: u64) (serverId: u64) (value: u64) (ackMessage: Message.t) : Client.t * Message.t :=
-    match uint.Z requestType with
-    | 0 => (c, coq_read c serverId)
-    | 1 => (c, coq_write c serverId value)
-    | 2 =>
-      match uint.Z ackMessage.(Message.S2C_Client_OperationType) with
-      | 0 => (Client.mk c.(Client.Id) c.(Client.NumberOfServers) c.(Client.WriteVersionVector) ackMessage.(Message.S2C_Client_VersionVector) c.(Client.SessionSemantic), Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0)
-      | 1 => (Client.mk c.(Client.Id) c.(Client.NumberOfServers) (ackMessage.(Message.S2C_Client_VersionVector)) c.(Client.ReadVersionVector) c.(Client.SessionSemantic), Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0)
+    match uint.nat requestType with
+    | 0%nat => (c, coq_read c serverId)
+    | 1%nat => (c, coq_write c serverId value)
+    | 2%nat =>
+      match uint.nat ackMessage.(Message.S2C_Client_OperationType) with
+      | 0%nat => (Client.mk c.(Client.Id) c.(Client.NumberOfServers) c.(Client.WriteVersionVector) ackMessage.(Message.S2C_Client_VersionVector) c.(Client.SessionSemantic), Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0)
+      | 1%nat => (Client.mk c.(Client.Id) c.(Client.NumberOfServers) (ackMessage.(Message.S2C_Client_VersionVector)) c.(Client.ReadVersionVector) c.(Client.SessionSemantic), Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0)
       | _ => (c, Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0)
       end
     | _ => (c, Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0)
@@ -55,30 +55,34 @@ Section heap.
 
   Context `{hG: !heapGS Σ}.
 
-  Lemma wp_maxTS (x: Slice.t) (xs: list w64) (y: Slice.t) (ys: list w64) (dx: dfrac) (dy: dfrac) :
+  Lemma wp_maxTS (n: nat) (x: Slice.t) (xs: list w64) (y: Slice.t) (ys: list w64) (dx: dfrac) (dy: dfrac) :
     {{{
         own_slice_small x uint64T dx xs ∗
         own_slice_small y uint64T dy ys ∗
-        ⌜length xs = length ys⌝
+        ⌜n = length xs /\ n = length ys⌝
     }}}
       CoqSessionClient.maxTS (slice_val x) (slice_val y)
     {{{
         ns, RET (slice_val ns);
         own_slice_small x uint64T dx xs ∗
         own_slice_small y uint64T dy ys ∗
-        own_slice ns uint64T (DfracOwn 1) (coq_maxTS xs ys)
+        own_slice ns uint64T (DfracOwn 1) (coq_maxTS xs ys) ∗
+        ⌜n = length (coq_maxTS xs ys)⌝
     }}}.
   Proof.
     replace (maxTS x y) with (CoqSessionServer.maxTS (slice_val x) (slice_val y)) by reflexivity.
-    iIntros "%Φ H_precondition HΦ".
-    wp_apply (versionVector.wp_maxTS with "[$H_precondition]").
+    iIntros "%Φ (H_xs & H_ys & [%LEN_xs %LEN_ys]) HΦ".
+    wp_apply (versionVector.wp_maxTS with "[$H_xs $H_ys]"). { iPureIntro. word. }
     iIntros "%ns (H_ns & H_xs & H_ys)". iApply "HΦ". iFrame.
+    iPureIntro. revert n xs ys LEN_xs LEN_ys; clear.
+    induction n as [ | n IH], xs as [ | x xs], ys as [ | y ys]; simpl; intros; try congruence.
+    f_equal; eapply IH; word.
   Qed.
 
-  Lemma wp_read (c: Client.t) (serverId: u64) (n: nat) cv :
+  (*Lemma wp_read (c: Client.t) (serverId: u64) (n: nat) cv :
     {{{
         is_client cv c n ∗
-        ⌜n = uint.nat c.(Client.NumberOfServers)⌝
+        ⌜CLIENT_INVARIANT c⌝
     }}}
       CoqSessionClient.read (client_val cv) (#serverId)
     {{{
@@ -86,7 +90,7 @@ Section heap.
         is_client cv c n ∗
         is_message msgv (coq_read c serverId) n n 0%nat
     }}}.
-  Proof. (**
+  Proof.
     rewrite redefine_client_val redefine_message_val. TypeVector.des cv. iIntros "%Φ (H_is_client & ->) HΦ".
     iDestruct "H_is_client" as "(%H1 & %H2 & H3 & %H4 & H5 & %H6 & %H7)".
     simplNotation; simpl; subst; rewrite /CoqSessionClient.read.
@@ -109,7 +113,7 @@ Section heap.
       iModIntro. simpl. iApply "HΦ".
       iSplitL "H3 H5".
       - iFrame. simplNotation; simpl; done.
-      - unfold coq_read. rewrite -> EQ. replace (uint.Z (W64 0)) with 0%Z by word.
+      - unfold coq_read. rewrite -> EQ. replace (uint.nat (W64 0)) with 0%nat by word.
         unfold is_message; iFrame; simplNotation; simpl.
         iSplitL "". { done. }
         iSplitL "". { done. }
@@ -147,7 +151,7 @@ Section heap.
       iModIntro. simpl. iApply "HΦ".
       iSplitL "H3 H5".
       - iFrame. simplNotation; simpl; done.
-      - unfold coq_read. rewrite -> EQ. replace (uint.Z (W64 1)) with 1%Z by word.
+      - unfold coq_read. rewrite -> EQ. replace (uint.nat (W64 1)) with 1%nat by word.
         unfold is_message; iFrame; simplNotation; simpl.
         iSplitL "". { done. }
         iSplitL "". { done. }
@@ -185,7 +189,7 @@ Section heap.
       iModIntro. simpl. iApply "HΦ".
       iSplitL "H3 H5".
       - iFrame. simplNotation; simpl; done.
-      - unfold coq_read. rewrite -> EQ. replace (uint.Z (W64 2)) with 2%Z by word.
+      - unfold coq_read. rewrite -> EQ. replace (uint.nat (W64 2)) with 2%nat by word.
         unfold is_message; iFrame; simplNotation; simpl.
         iSplitL "". { done. }
         iSplitL "". { done. }
@@ -208,14 +212,157 @@ Section heap.
         done.
     }
     wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 3))) as [ | ] eqn: Heqb2.
-    { admit. }
-    admit.
-  Qed. *) Admitted.
+    { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_NewSlice). iIntros "%s1 H_s1". replace (replicate (uint.nat (W64 0)) u64_IntoVal .(IntoVal_def w64)) with ( @nil w64) by reflexivity.
+      wp_pures. wp_apply (wp_SliceAppendSlice with "[H5 H_s1]"). { repeat econstructor; eauto. } { iFrame. } clear s1. iIntros "%s1 [H_s1 H5]".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_load.
+      apply bool_decide_eq_true in Heqb2.
+      assert (c .(Client.SessionSemantic) = W64 3) as EQ by congruence.
+      replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 0), (#(W64 0), (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 0, W64 0, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
+      iModIntro. simpl. iApply "HΦ".
+      iSplitL "H3 H5".
+      - iFrame. simplNotation; simpl; done.
+      - unfold coq_read. rewrite -> EQ. replace (uint.nat (W64 3)) with 3%nat by word.
+        unfold is_message; iFrame; simplNotation; simpl.
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iApply own_slice_small_nil; eauto. }
+        iSplitL "". { iPureIntro. word. }
+        done.
+    }
+    wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 4))) as [ | ] eqn: Heqb3.
+    { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_NewSlice). iIntros "%s1 H_s1". replace (replicate (uint.nat (W64 0)) u64_IntoVal .(IntoVal_def w64)) with ( @nil w64) by reflexivity.
+      wp_pures. wp_apply (wp_SliceAppendSlice with "[H3 H_s1]"). { repeat econstructor; eauto. } { iFrame. } clear s1. iIntros "%s1 [H_s1 H3]".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_load.
+      apply bool_decide_eq_true in Heqb3.
+      assert (c .(Client.SessionSemantic) = W64 4) as EQ by congruence.
+      replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 0), (#(W64 0), (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 0, W64 0, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
+      iModIntro. simpl. iApply "HΦ".
+      iSplitL "H3 H5".
+      - iFrame. simplNotation; simpl; done.
+      - unfold coq_read. rewrite -> EQ. replace (uint.nat (W64 4)) with 4%nat by word.
+        unfold is_message; iFrame; simplNotation; simpl.
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iApply own_slice_small_nil; eauto. }
+        iSplitL "". { iPureIntro. word. }
+        done.
+    }
+    wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 5))) as [ | ] eqn: Heqb4.
+    { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_maxTS (uint.nat (c.(Client.NumberOfServers))) with "[$H3 $H5]"). { iPureIntro. word. } iIntros "%s1 (H3 & H5 & [H_s1 %LEN])".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_load.
+      apply bool_decide_eq_true in Heqb4.
+      assert (c .(Client.SessionSemantic) = W64 5) as EQ by congruence.
+      replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 0), (#(W64 0), (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 0, W64 0, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
+      iModIntro. simpl. iApply "HΦ".
+      iSplitL "H3 H5".
+      - iFrame. simplNotation; simpl; done.
+      - unfold coq_read. rewrite -> EQ. replace (uint.nat (W64 5)) with 5%nat by word.
+        unfold is_message; iFrame; simplNotation; simpl.
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iApply own_slice_small_nil; eauto. }
+        iSplitL "". { iPureIntro. word. }
+        done.
+    }
+    wp_pures. wp_load. replace (Φ (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0))) by reflexivity.
+    iModIntro. iApply "HΦ".
+    iSplitL "H3 H5".
+    - iFrame. simplNotation; simpl; done.
+    - rewrite -> bool_decide_eq_false in Heqb, Heqb0, Heqb1, Heqb2, Heqb3, Heqb4.
+      assert (c.(Client.SessionSemantic) ≠ (W64 0)) as NE0 by congruence.
+      assert (c.(Client.SessionSemantic) ≠ (W64 1)) as NE1 by congruence.
+      assert (c.(Client.SessionSemantic) ≠ (W64 2)) as NE2 by congruence.
+      assert (c.(Client.SessionSemantic) ≠ (W64 3)) as NE3 by congruence.
+      assert (c.(Client.SessionSemantic) ≠ (W64 4)) as NE4 by congruence.
+      assert (c.(Client.SessionSemantic) ≠ (W64 5)) as NE5 by congruence.
+      unfold coq_read. destruct (uint.nat c .(Client.SessionSemantic)) as [ | [ | [ | [ | [ | [ | n]]]]]] eqn: H_n; try word.
+      unfold is_message; iFrame; simplNotation; simpl.
+      unfold is_message; iFrame; simplNotation; simpl.
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { iApply (own_slice_small_nil); eauto. }
+      iSplitL "". { rewrite length_replicate. done. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { iApply own_slice_small_nil; eauto. }
+      iSplitL "". { iPureIntro. word. }
+      done.
+  Qed.
 
   Lemma wp_write (c: Client.t) (serverId: u64) (value: u64) (n: nat) cv :
     {{{
         is_client cv c n ∗
-        ⌜n = uint.nat c.(Client.NumberOfServers)⌝
+        ⌜CLIENT_INVARIANT c⌝
     }}}
       CoqSessionClient.write (client_val cv) (#serverId) (#value)
     {{{
@@ -236,11 +383,11 @@ Section heap.
     {{{
         cv' msgv', RET (client_val cv', message_val msgv');
         is_client cv' (coq_processRequest c requestType serverId value ackMessage).1 n ∗
-        is_message msgv' (coq_processRequest c requestType serverId value ackMessage).2 n (if (uint.Z requestType =? 0) || (uint.Z requestType =? 1) then n else 0%nat) 0%nat ∗
+        is_message msgv' (coq_processRequest c requestType serverId value ackMessage).2 n (if (uint.Z requestType =? 0)%Z || (uint.Z requestType =? 1)%Z then n else 0%nat) 0%nat ∗
         is_message msgv ackMessage n n n ∗
-        ⌜n = uint.nat (coq_processRequest c requestType serverId value ackMessage).1.(Client.NumberOfServers)⌝
+        ⌜CLIENT_INVARIANT c⌝
     }}}.
   Proof.
-  Admitted.
+  Admitted. *)
 
 End heap.

--- a/src/program_proof/session/coq_session_client.v
+++ b/src/program_proof/session/coq_session_client.v
@@ -619,24 +619,22 @@ Section heap.
     iPoseProof (own_slice_small_sz with "[$H5]") as "%LENGTH2".
     wp_pures. wp_apply wp_ref_to. { repeat econstructor; eauto. } iIntros "%msg H_msg".
     wp_pures. wp_if_destruct.
-    { wp_apply (wp_read c with "[H3 H5]"). { iFrame. instantiate (1 := uint.nat c.(Client.NumberOfServers)). simplNotation; simpl; iPureIntro. tauto. } iIntros "%msgv [H_is_client H_msgv]".
+    { wp_apply (wp_read c serverId (uint.nat c.(Client.NumberOfServers)) with "[H3 H5]"). { iFrame. simplNotation; simpl; iPureIntro. tauto. } iIntros "%msgv [H_is_client H_msgv]".
       replace (message_val msgv) with (message_into_val.(to_val) msgv) by reflexivity.
       wp_pures; eapply (tac_wp_store_ty _ _ _ _ _ _ []%list); [repeat econstructor; eauto | tc_solve | let l := msg in iAssumptionCore | reflexivity | simpl].
       wp_pures. wp_load.
       wp_pures. iModIntro. iApply "HΦ".
       replace (uint.Z (W64 0) =? 0)%Z with true by reflexivity. rewrite orb_true_l.
-      iFrame; simplNotation; simpl. iPureIntro.
-      repeat (split; trivial).
+      iFrame; simplNotation; simpl. iPureIntro; tauto.
     }
     wp_pures. wp_if_destruct.
-    { wp_apply (wp_write c with "[H3 H5]"). { iFrame. instantiate (1 := uint.nat c.(Client.NumberOfServers)). simplNotation; simpl; iPureIntro. tauto. } iIntros "%msgv [H_is_client H_msgv]".
+    { wp_apply (wp_write c serverId value (uint.nat c.(Client.NumberOfServers)) with "[H3 H5]"). { iFrame. simplNotation; simpl; iPureIntro. tauto. } iIntros "%msgv [H_is_client H_msgv]".
       replace (message_val msgv) with (message_into_val.(to_val) msgv) by reflexivity.
       wp_pures; eapply (tac_wp_store_ty _ _ _ _ _ _ []%list); [repeat econstructor; eauto | tc_solve | let l := msg in iAssumptionCore | reflexivity | simpl].
       wp_pures. wp_load.
       wp_pures. iModIntro. iApply "HΦ".
       replace (uint.Z (W64 1) =? 1)%Z with true by reflexivity. rewrite orb_true_r.
-      iFrame; simplNotation; simpl. iPureIntro.
-      repeat (split; trivial).
+      iFrame; simplNotation; simpl. iPureIntro; tauto.
     }
     wp_pures. wp_if_destruct.
     { wp_pures. wp_if_destruct.

--- a/src/program_proof/session/coq_session_client.v
+++ b/src/program_proof/session/coq_session_client.v
@@ -79,7 +79,7 @@ Section heap.
     f_equal; eapply IH; word.
   Qed.
 
-  (*Lemma wp_read (c: Client.t) (serverId: u64) (n: nat) cv :
+  Lemma wp_read (c: Client.t) (serverId: u64) (n: nat) cv :
     {{{
         is_client cv c n ∗
         ⌜CLIENT_INVARIANT c⌝
@@ -91,8 +91,8 @@ Section heap.
         is_message msgv (coq_read c serverId) n n 0%nat
     }}}.
   Proof.
-    rewrite redefine_client_val redefine_message_val. TypeVector.des cv. iIntros "%Φ (H_is_client & ->) HΦ".
-    iDestruct "H_is_client" as "(%H1 & %H2 & H3 & %H4 & H5 & %H6 & %H7)".
+    rewrite redefine_client_val redefine_message_val. TypeVector.des cv. iIntros "%Φ (H_is_client & %H_invariant) HΦ".
+    iDestruct "H_is_client" as "(%H1 & %H2 & -> & H3 & %H4 & H5 & %H6 & %H7)". destruct H_invariant as [? ?].
     simplNotation; simpl; subst; rewrite /CoqSessionClient.read.
     iPoseProof (own_slice_small_sz with "[$H3]") as "%LENGTH1".
     iPoseProof (own_slice_small_sz with "[$H5]") as "%LENGTH2".
@@ -336,27 +336,6 @@ Section heap.
       assert (c.(Client.SessionSemantic) ≠ (W64 4)) as NE4 by congruence.
       assert (c.(Client.SessionSemantic) ≠ (W64 5)) as NE5 by congruence.
       unfold coq_read. destruct (uint.nat c .(Client.SessionSemantic)) as [ | [ | [ | [ | [ | [ | n]]]]]] eqn: H_n; try word.
-      unfold is_message; iFrame; simplNotation; simpl.
-      unfold is_message; iFrame; simplNotation; simpl.
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { iApply (own_slice_small_nil); eauto. }
-      iSplitL "". { rewrite length_replicate. done. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { done. }
-      iSplitL "". { iApply own_slice_small_nil; eauto. }
-      iSplitL "". { iPureIntro. word. }
-      done.
   Qed.
 
   Lemma wp_write (c: Client.t) (serverId: u64) (value: u64) (n: nat) cv :
@@ -371,13 +350,258 @@ Section heap.
         is_message msgv (coq_write c serverId value) n n 0%nat
     }}}.
   Proof.
-  Admitted.
+    rewrite redefine_client_val redefine_message_val. TypeVector.des cv. iIntros "%Φ (H_is_client & %H_invariant) HΦ".
+    iDestruct "H_is_client" as "(%H1 & %H2 & -> & H3 & %H4 & H5 & %H6 & %H7)". destruct H_invariant as [? ?].
+    simplNotation; simpl; subst; rewrite /CoqSessionClient.write.
+    iPoseProof (own_slice_small_sz with "[$H3]") as "%LENGTH1".
+    iPoseProof (own_slice_small_sz with "[$H5]") as "%LENGTH2".
+    wp_pures. wp_apply wp_ref_to. { repeat econstructor; eauto. } iIntros "%reply H_reply".
+    wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 0))) as [ | ] eqn: Heqb.
+    { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_NewSlice). iIntros "%s1 H_s1".
+      iPoseProof (own_slice_sz with "[$H_s1]") as "%LENGTH3". rewrite length_replicate in LENGTH3.
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_load.
+      apply bool_decide_eq_true in Heqb.
+      assert (c .(Client.SessionSemantic) = W64 0) as EQ by congruence.
+      replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 1), (#value, (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 1, value, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
+      iModIntro. simpl. iApply "HΦ".
+      iSplitL "H3 H5".
+      - iFrame. simplNotation; simpl; done.
+      - unfold coq_write. rewrite -> EQ. replace (uint.nat (W64 0)) with 0%nat by word.
+        unfold is_message; iFrame; simplNotation; simpl.
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
+        iSplitL "". { rewrite length_replicate. done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iApply own_slice_small_nil; eauto. }
+        iSplitL "". { iPureIntro. word. }
+        done.
+    }
+    wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 3))) as [ | ] eqn: Heqb0.
+    { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_NewSlice). iIntros "%s1 H_s1".
+      iPoseProof (own_slice_sz with "[$H_s1]") as "%LENGTH3". rewrite length_replicate in LENGTH3.
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_load.
+      apply bool_decide_eq_true in Heqb0.
+      assert (c .(Client.SessionSemantic) = W64 3) as EQ by congruence.
+      replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 1), (#value, (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 1, value, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
+      iModIntro. simpl. iApply "HΦ".
+      iSplitL "H3 H5".
+      - iFrame. simplNotation; simpl; done.
+      - unfold coq_write. rewrite -> EQ. replace (uint.nat (W64 3)) with 3%nat by word.
+        unfold is_message; iFrame; simplNotation; simpl.
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
+        iSplitL "". { rewrite length_replicate. done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iApply own_slice_small_nil; eauto. }
+        iSplitL "". { iPureIntro. word. }
+        done.
+    }
+    wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 4))) as [ | ] eqn: Heqb1.
+    { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_NewSlice). iIntros "%s1 H_s1".
+      iPoseProof (own_slice_sz with "[$H_s1]") as "%LENGTH3". rewrite length_replicate in LENGTH3.
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_load.
+      apply bool_decide_eq_true in Heqb1.
+      assert (c .(Client.SessionSemantic) = W64 4) as EQ by congruence.
+      replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 1), (#value, (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 1, value, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
+      iModIntro. simpl. iApply "HΦ".
+      iSplitL "H3 H5".
+      - iFrame. simplNotation; simpl; done.
+      - unfold coq_write. rewrite -> EQ. replace (uint.nat (W64 4)) with 4%nat by word.
+        unfold is_message; iFrame; simplNotation; simpl.
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
+        iSplitL "". { rewrite length_replicate. done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iApply own_slice_small_nil; eauto. }
+        iSplitL "". { iPureIntro. word. }
+        done.
+    }
+    wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 1))) as [ | ] eqn: Heqb2.
+    { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_NewSlice). iIntros "%s1 H_s1".
+      wp_pures. wp_apply (wp_SliceAppendSlice with "[H5 H_s1]"). { repeat econstructor; eauto. } { iFrame. } clear s1. iIntros "%s1 [H_s1 H5]".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_load.
+      apply bool_decide_eq_true in Heqb2.
+      assert (c .(Client.SessionSemantic) = W64 1) as EQ by congruence.
+      replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 1), (#value, (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 1, value, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
+      iModIntro. simpl. iApply "HΦ".
+      iSplitL "H3 H5".
+      - iFrame. simplNotation; simpl; done.
+      - unfold coq_write. rewrite -> EQ. replace (uint.nat (W64 1)) with 1%nat by word.
+        unfold is_message; iFrame; simplNotation; simpl.
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
+        iSplitL "". { iPureIntro. word. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iApply own_slice_small_nil; eauto. }
+        iSplitL "". { iPureIntro. word. }
+        done.
+    }
+    wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 2))) as [ | ] eqn: Heqb3.
+    { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_NewSlice). iIntros "%s1 H_s1".
+      wp_pures. wp_apply (wp_SliceAppendSlice with "[H3 H_s1]"). { repeat econstructor; eauto. } { iFrame. } clear s1. iIntros "%s1 [H_s1 H3]".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_load.
+      apply bool_decide_eq_true in Heqb3.
+      assert (c .(Client.SessionSemantic) = W64 2) as EQ by congruence.
+      replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 1), (#value, (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 1, value, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
+      iModIntro. simpl. iApply "HΦ".
+      iSplitL "H3 H5".
+      - iFrame. simplNotation; simpl; done.
+      - unfold coq_write. rewrite -> EQ. replace (uint.nat (W64 2)) with 2%nat by word.
+        unfold is_message; iFrame; simplNotation; simpl.
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
+        iSplitL "". { iPureIntro. word. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iApply own_slice_small_nil; eauto. }
+        iSplitL "". { iPureIntro. word. }
+        done.
+    }
+    wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 5))) as [ | ] eqn: Heqb4.
+    { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_maxTS (uint.nat (c.(Client.NumberOfServers))) with "[$H3 $H5]"). { iPureIntro. word. } iIntros "%s1 (H3 & H5 & [H_s1 %LEN])".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_load.
+      apply bool_decide_eq_true in Heqb4.
+      assert (c .(Client.SessionSemantic) = W64 5) as EQ by congruence.
+      replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 1), (#value, (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 1, value, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
+      iModIntro. simpl. iApply "HΦ".
+      iSplitL "H3 H5".
+      - iFrame. simplNotation; simpl; done.
+      - unfold coq_write. rewrite -> EQ. replace (uint.nat (W64 5)) with 5%nat by word.
+        unfold is_message; iFrame; simplNotation; simpl.
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
+        iSplitL "". { iPureIntro. word. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iApply own_slice_small_nil; eauto. }
+        iSplitL "". { iPureIntro. word. }
+        done.
+    }
+    wp_pures. wp_load. replace (Φ (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0))) by reflexivity.
+    iModIntro. iApply "HΦ".
+    iSplitL "H3 H5".
+    - iFrame. simplNotation; simpl; done.
+    - rewrite -> bool_decide_eq_false in Heqb, Heqb0, Heqb1, Heqb2, Heqb3, Heqb4.
+      assert (c.(Client.SessionSemantic) ≠ (W64 0)) as NE0 by congruence.
+      assert (c.(Client.SessionSemantic) ≠ (W64 1)) as NE1 by congruence.
+      assert (c.(Client.SessionSemantic) ≠ (W64 2)) as NE2 by congruence.
+      assert (c.(Client.SessionSemantic) ≠ (W64 3)) as NE3 by congruence.
+      assert (c.(Client.SessionSemantic) ≠ (W64 4)) as NE4 by congruence.
+      assert (c.(Client.SessionSemantic) ≠ (W64 5)) as NE5 by congruence.
+      unfold coq_read. destruct (uint.nat c .(Client.SessionSemantic)) as [ | [ | [ | [ | [ | [ | n]]]]]] eqn: H_n; try word.
+  Qed.
 
   Lemma wp_processRequest (c: Client.t) (requestType: u64) (serverId: u64) (value: u64) (ackMessage: Message.t) (n: nat) cv msgv :
     {{{
         is_client cv c n ∗
         is_message msgv ackMessage n n n ∗
-        ⌜n = uint.nat c.(Client.NumberOfServers)⌝
+        ⌜CLIENT_INVARIANT c⌝
     }}}
       CoqSessionClient.processRequest (client_val cv) (#requestType) (#serverId) (#value) (message_val msgv)
     {{{
@@ -385,9 +609,107 @@ Section heap.
         is_client cv' (coq_processRequest c requestType serverId value ackMessage).1 n ∗
         is_message msgv' (coq_processRequest c requestType serverId value ackMessage).2 n (if (uint.Z requestType =? 0)%Z || (uint.Z requestType =? 1)%Z then n else 0%nat) 0%nat ∗
         is_message msgv ackMessage n n n ∗
-        ⌜CLIENT_INVARIANT c⌝
+        ⌜CLIENT_INVARIANT (coq_processRequest c requestType serverId value ackMessage).1⌝
     }}}.
   Proof.
-  Admitted. *)
+    TypeVector.des cv. TypeVector.des msgv. iIntros "%Φ (H_is_client & H_is_message & %H_invariant) HΦ".
+    iDestruct "H_is_client" as "(%H1 & %H2 & -> & H3 & %H4 & H5 & %H6 & %H7)". iDestruct "H_is_message" as "(%H11 & %H12 & %H13 & %H14 & %H15 & H16 & %H17 & %H18 & %H19 & H20 & %H21 & %H22 & %H23 & %H24 & %H25 & %H26 & H27 & %H28 & %H29 & %H30)".
+    simplNotation; simpl; subst; rewrite /CoqSessionClient.processRequest.
+    iPoseProof (own_slice_small_sz with "[$H3]") as "%LENGTH1".
+    iPoseProof (own_slice_small_sz with "[$H5]") as "%LENGTH2".
+    wp_pures. wp_apply wp_ref_to. { repeat econstructor; eauto. } iIntros "%msg H_msg".
+    wp_pures. wp_if_destruct.
+    { wp_apply (wp_read c with "[H3 H5]"). { iFrame. instantiate (1 := uint.nat c.(Client.NumberOfServers)). simplNotation; simpl; iPureIntro. tauto. } iIntros "%msgv [H_is_client H_msgv]".
+      replace (message_val msgv) with (message_into_val.(to_val) msgv) by reflexivity.
+      wp_pures; eapply (tac_wp_store_ty _ _ _ _ _ _ []%list); [repeat econstructor; eauto | tc_solve | let l := msg in iAssumptionCore | reflexivity | simpl].
+      wp_pures. wp_load.
+      wp_pures. iModIntro. iApply "HΦ".
+      replace (uint.Z (W64 0) =? 0)%Z with true by reflexivity. rewrite orb_true_l.
+      iFrame; simplNotation; simpl. iPureIntro.
+      repeat (split; trivial).
+    }
+    wp_pures. wp_if_destruct.
+    { wp_apply (wp_write c with "[H3 H5]"). { iFrame. instantiate (1 := uint.nat c.(Client.NumberOfServers)). simplNotation; simpl; iPureIntro. tauto. } iIntros "%msgv [H_is_client H_msgv]".
+      replace (message_val msgv) with (message_into_val.(to_val) msgv) by reflexivity.
+      wp_pures; eapply (tac_wp_store_ty _ _ _ _ _ _ []%list); [repeat econstructor; eauto | tc_solve | let l := msg in iAssumptionCore | reflexivity | simpl].
+      wp_pures. wp_load.
+      wp_pures. iModIntro. iApply "HΦ".
+      replace (uint.Z (W64 1) =? 1)%Z with true by reflexivity. rewrite orb_true_r.
+      iFrame; simplNotation; simpl. iPureIntro.
+      repeat (split; trivial).
+    }
+    wp_pures. wp_if_destruct.
+    { wp_pures. wp_if_destruct.
+      { wp_apply wp_NewSlice. iIntros "%s1 H_s1". replace (replicate (uint.nat (W64 0)) u64_IntoVal .(IntoVal_def w64)) with ( @nil w64) by reflexivity.
+        admit.
+      }
+      wp_pures. wp_if_destruct.
+      { wp_apply wp_NewSlice. iIntros "%s1 H_s1". replace (replicate (uint.nat (W64 0)) u64_IntoVal .(IntoVal_def w64)) with ( @nil w64) by reflexivity.
+        admit.
+      }
+      wp_pures. wp_load.
+      wp_pures. replace (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V with (message_val (W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)) by reflexivity.
+      iModIntro. iApply "HΦ".
+      replace (uint.Z (W64 2) =? 0)%Z with false by reflexivity. replace (uint.Z (W64 2) =? 1)%Z with false by reflexivity. simpl.
+      unfold coq_processRequest. replace (uint.nat (W64 2)) with 2%nat by word.
+      destruct (uint.nat ackMessage .(Message.S2C_Client_OperationType)) as [ | [ | n]] eqn: H_OBS; try word.
+      iFrame. simplNotation; simpl.
+      iSplitL "". { iPureIntro. tauto. }
+      iSplitR "".
+      { unfold is_message; iFrame; simplNotation; simpl.
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iApply (own_slice_small_nil); eauto. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iApply own_slice_small_nil; eauto. }
+        iSplitL "". { iPureIntro. word. }
+        done.
+      }
+      iPureIntro; tauto.
+    }
+    wp_pures. wp_load.
+    wp_pures. replace (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V with (message_val (W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)) by reflexivity.
+    iModIntro. iApply "HΦ".
+    replace (uint.Z (W64 2) =? 0)%Z with false by reflexivity. replace (uint.Z (W64 2) =? 1)%Z with false by reflexivity. simpl.
+    unfold coq_processRequest. destruct (uint.nat requestType) as [ | [ | [ | n]]] eqn: H_OBS; try word; simpl.
+    replace (uint.Z requestType =? 0)%Z with false by word. replace (uint.Z requestType =? 1)%Z with false by word. simpl.
+    iFrame. simplNotation; simpl.
+    iSplitL "". { iPureIntro. tauto. }
+    iSplitR "".
+    { unfold is_message; iFrame; simplNotation; simpl.
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { iApply (own_slice_small_nil); eauto. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { done. }
+      iSplitL "". { iApply own_slice_small_nil; eauto. }
+      iSplitL "". { iPureIntro. word. }
+      done.
+    }
+    iPureIntro; tauto.
+  Admitted.
 
 End heap.

--- a/src/program_proof/session/coq_session_client.v
+++ b/src/program_proof/session/coq_session_client.v
@@ -18,423 +18,425 @@ Module CoqSessionClient.
     | 2 => Message.mk 0 (c.(Client.Id)) serverId 0 0 (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
     | 3 => Message.mk 0 (c.(Client.Id)) serverId 0 0 (c.(Client.ReadVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
     | 4 => Message.mk 0 (c.(Client.Id)) serverId 0 0 (c.(Client.WriteVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
-    | _ => Message.mk 0 (c.(Client.Id)) serverId 0 0 (coq_maxTS c.(Client.WriteVersionVector) c.(Client.ReadVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
+    | 5 => Message.mk 0 (c.(Client.Id)) serverId 0 0 (coq_maxTS c.(Client.WriteVersionVector) c.(Client.ReadVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
+    | _ => Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0
     end.
 
   Definition coq_write (c: Client.t) (serverId: u64) (value: u64) : Message.t :=
     match uint.Z c.(Client.SessionSemantic) with
     | 0 => Message.mk 0 (c.(Client.Id)) serverId 1 value (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
     | 1 => Message.mk 0 (c.(Client.Id)) serverId 1 value (c.(Client.ReadVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
-    | 2 => Message.mk 0 (c.(Client.Id)) serverId 1 value (c.(Client.WriteVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0                    
+    | 2 => Message.mk 0 (c.(Client.Id)) serverId 1 value (c.(Client.WriteVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
     | 3 => Message.mk 0 (c.(Client.Id)) serverId 1 value (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
     | 4 => Message.mk 0 (c.(Client.Id)) serverId 1 value (replicate (uint.nat c.(Client.NumberOfServers)) (W64 0)) 0 0 [] 0 0 0 0 0 0 [] 0 0
-    | _ => Message.mk 0 (c.(Client.Id)) serverId 1 value (coq_maxTS c.(Client.WriteVersionVector) c.(Client.ReadVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
+    | 5 => Message.mk 0 (c.(Client.Id)) serverId 1 value (coq_maxTS c.(Client.WriteVersionVector) c.(Client.ReadVersionVector)) 0 0 [] 0 0 0 0 0 0 [] 0 0
+    | _ => Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0
     end.
 
-  Definition coq_processRequest (c: Client.t) (requestType serverId value: u64) (ackMessage: Message.t) : (Client.t * Message.t) :=
-    match (uint.Z requestType) with
+  Definition coq_processRequest (c: Client.t) (requestType: u64) (serverId: u64) (value: u64) (ackMessage: Message.t) : Client.t * Message.t :=
+    match uint.Z requestType with
     | 0 => (c, coq_read c serverId)
     | 1 => (c, coq_write c serverId value)
-    | _ =>
-        if ((uint.Z ackMessage.(Message.MessageType)) =? 4) then 
-          match (uint.Z ackMessage.(Message.S2C_Client_OperationType)) with
-          | 0 => (Client.mk c.(Client.Id) c.(Client.NumberOfServers) c.(Client.WriteVersionVector) ackMessage.(Message.S2C_Client_VersionVector) c.(Client.SessionSemantic), Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0)
-          | _ => (Client.mk c.(Client.Id) c.(Client.NumberOfServers) (ackMessage.(Message.S2C_Client_VersionVector)) c.(Client.ReadVersionVector) c.(Client.SessionSemantic), Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0)
-          end
-        else
-          (c, Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0)
+    | 2 =>
+      match uint.Z ackMessage.(Message.S2C_Client_OperationType) with
+      | 0 => (Client.mk c.(Client.Id) c.(Client.NumberOfServers) c.(Client.WriteVersionVector) ackMessage.(Message.S2C_Client_VersionVector) c.(Client.SessionSemantic), Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0)
+      | 1 => (Client.mk c.(Client.Id) c.(Client.NumberOfServers) (ackMessage.(Message.S2C_Client_VersionVector)) c.(Client.ReadVersionVector) c.(Client.SessionSemantic), Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0)
+      | _ => (c, Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0)
+      end
+    | _ => (c, Message.mk 0 0 0 0 0 [] 0 0 [] 0 0 0 0 0 0 [] 0 0)
     end.
-
-  Section heap.
-
-    Context `{hG: !heapGS Σ}.
-
-    Lemma wp_maxTwoInts (x: w64) (y: w64) :
-      {{{
-          True
-      }}}
-        CoqSessionClient.maxTwoInts #x #y 
-      {{{
-          r , RET #r;
-          ⌜r = coq_maxTwoInts x y⌝
-      }}}.
-    Proof.
-      iIntros (Φ) "H H1".
-      rewrite /maxTwoInts. wp_pures.
-      wp_if_destruct.
-      - iModIntro. iApply "H1". iPureIntro.
-        unfold coq_maxTwoInts. apply Z.gtb_lt in Heqb.
-        rewrite Heqb. auto.
-      - iModIntro. iApply "H1". iPureIntro.
-        rewrite /coq_maxTwoInts.
-        assert (uint.Z y >= uint.Z x) by word.
-        assert (uint.Z x >? uint.Z y = false) by word.
-        rewrite H0.
-        auto.
-    Qed.
-
-    Lemma wp_maxTS (x: Slice.t) (xs: list w64) (y: Slice.t) (ys: list w64) (d: dfrac) (d': dfrac) :
-      {{{
-          own_slice_small x uint64T d xs ∗
-          own_slice_small y uint64T d' ys ∗
-          ⌜length xs = length ys⌝
-      }}}
-        CoqSessionClient.maxTS x y 
-      {{{
-          (s': Slice.t), RET slice_val s'; 
-          own_slice s' uint64T (DfracOwn 1) (coq_maxTS xs ys) ∗ 
-          own_slice_small x uint64T d xs ∗
-          own_slice_small y uint64T d' ys 
-      }}}.
-    Proof.
-      iIntros (Φ) "(H & H1 & %H3) H2".
-      rewrite /maxTS.
-      iDestruct (own_slice_small_sz with "H") as %Hsz_x.
-      iDestruct (own_slice_small_sz with "H1") as %Hsz_y.
-      wp_pures. wp_apply wp_ref_to; auto.
-      iIntros (index) "index". wp_pures.
-      wp_pures. wp_apply wp_slice_len.
-      wp_apply wp_ref_to; auto.
-      iIntros (len) "len". wp_pures.
-      wp_bind (NewSlice uint64T (slice.len x)).
-      wp_apply wp_slice_len.
-      wp_apply wp_new_slice; auto.
-      iIntros (s') "s'". 
-      wp_apply wp_ref_to; auto.
-      iIntros (slice) "slice". wp_pures.
-      wp_apply (wp_forBreak_cond
-                  (λ continue, ∃ (i: w64) (l: list w64),
-                      own_slice_small x uint64T d xs ∗
-                      own_slice_small y uint64T d' ys ∗
-                      own_slice s' uint64T (DfracOwn 1) l ∗ 
-                      index ↦[uint64T] #i ∗
-                      len ↦[uint64T] #(length xs) ∗
-                      slice ↦[slice.T uint64T] s' ∗ 
-                      ⌜continue = false -> uint.nat i = (length xs)⌝ ∗
-                      ⌜length l = length xs⌝ ∗
-                      ⌜forall (i': nat),
-                    i' < uint.nat i <= length xs ->
-                    forall (x y: w64), xs !! i' = Some x ->
-                                        ys !! i' = Some y ->
-                                        l !! i' = Some (coq_maxTwoInts x y)⌝ ∗
-                                        ⌜uint.nat i <= length xs⌝ 
-                  )%I
-                with "[] [H H1 index len s' slice]").
-      - iIntros (?). iModIntro. iIntros "H1 H2".
-        iNamed "H1". iDestruct "H1"
-          as "(Hx & Hy & H4 & H5 & H6 & H7 & %H8 & %H9 & %H10 & %H11)".
-        wp_pures. wp_load. wp_load. wp_if_destruct.
-        + wp_pures. wp_load.
-          wp_bind (maxTwoInts _ _)%E.
-          iDestruct "H4" as "[Hs Hsc]".
-          assert (uint.nat i < length xs)%nat by word.
-          rewrite H3 in H. eapply list_lookup_lt in H.
-          destruct H as [x0 H].
-          assert (uint.nat i < length xs)%nat by word.
-          eapply list_lookup_lt in H0.
-          destruct H0 as [y0 H0].
-          wp_apply (wp_SliceGet with "[$Hy]"). { auto. }
-          iIntros "Hy". wp_load. wp_apply (wp_SliceGet with "[$Hx]"). { auto. }
-          iIntros "Hx".
-          wp_apply (wp_maxTwoInts). iIntros (r) "%H12".
-          wp_load. wp_load.
-          wp_apply (wp_SliceSet with "[$Hs]").
-          { iPureIntro. eapply lookup_lt_is_Some_2. word. }
-          iIntros "H11". wp_pures. wp_load. wp_store. iModIntro.
-          iApply "H2". iExists (w64_word_instance.(word.add) i (W64 1)).
-          iExists (<[uint.nat i:=r]> l)%E. iFrame.
-          iSplit. { auto. }
-          iSplit. { iPureIntro. rewrite <- H9. apply length_insert. }
-          iSplit. { iPureIntro. intros. destruct (decide (i' = uint.nat i)).
-                    - rewrite list_lookup_insert_Some.
-                      left.
-                      split. { auto. }
-                      split. { subst. rewrite H4 in H. rewrite H2 in H0. inversion H. inversion H0.
-                              auto. }
-                      word.
-                    - rewrite Z.lt_le_pred in H1.
-                      assert ((Z.pred (uint.nat (w64_word_instance.(word.add) i (W64 1)))) = uint.nat i) by word.
-                      rewrite H5 in H1.
-                      destruct H1. assert(uint.nat i ≠ i') by word.
-                      apply (list_lookup_insert_ne l (uint.nat i) (i') r) in H7.
-                      rewrite H7. eapply H10; try eassumption.
-                      word.
-          }
-          word.
-        + iModIntro. iApply "H2". iExists i. iExists l. iFrame. iPureIntro. split; auto. word.
-      - assert (zero_val uint64T = #(W64 0)). { unfold zero_val. simpl. auto. }
-        rewrite H. iExists (W64 0).
-        iExists (replicate (uint.nat x.(Slice.sz)) (W64 0))%V.
-        iFrame.
-        iSplitL "s'". { rewrite /own_slice. rewrite untype_replicate. iFrame. }
-        iSplitL "len". { rewrite Hsz_x.
-                        assert (#(W64 (uint.nat x.(Slice.sz))) = #x.(Slice.sz)). {
-                          f_equal. rewrite w64_to_nat_id. auto. }
-                        rewrite H0. iFrame. }
-        iPureIntro.
-        split. { intros. inversion H0. }
-        split. { rewrite length_replicate. auto. }
-        split. { intros. word. }
-        word.
-      - iIntros "H". wp_pures. iNamed "H". iDestruct "H" as "(H1 & H3 & H4 & H5 & H6 & H7 & %H8 & %H9 & %H10 & %H11)".
-        wp_load. iModIntro. iApply "H2". iFrame.
-        assert (coq_maxTS xs ys = l). {
-          clear Hsz_x.
-          clear Hsz_y.        
-          generalize dependent ys. generalize dependent l. generalize dependent i.
-          induction xs.
-          + intros. inversion H9. apply nil_length_inv in H0. rewrite H0. auto.
-          + induction ys.
-            * intros. inversion H3.
-            * clear IHys. intros.
-              assert (uint.nat (uint.nat i - 1%nat)%nat = ((uint.nat i) - 1)%nat) by word.
-              destruct (decide (uint.Z a >? uint.Z a0 = true)).
-              { inversion H3.
-                assert (0%nat < uint.nat i <= length (a :: xs)). {
-                  destruct H8; auto. rewrite H3. repeat rewrite length_cons. word. }
-                rewrite /coq_maxTS. rewrite /coq_maxTwoInts.
-                rewrite e.
-                eapply H10 in H0.
-                - rewrite <- head_lookup in H0. rewrite head_Some in H0. destruct H0 as [l' H0].
-                  rewrite H0. f_equal.
-                  + assert (a = coq_maxTwoInts a a0). { rewrite /coq_maxTwoInts. rewrite e. auto. }
-                    eassumption.
-                  + eapply IHxs.
-                    * intros. destruct H8; auto.
-                      rewrite length_cons in H3. assert (uint.nat (uint.nat i - 1)%nat = length xs) by word.
-                      eassumption.
-                    * rewrite H. rewrite length_cons in H11. word.
-                    * rewrite length_cons in H9.
-                      assert (length l = (1 + length l')%nat). { rewrite H0. simpl. auto. }
-                      rewrite H9 in H2. word.
-                    * auto.
-                    * intros. assert (l !! (S i')%nat = l' !! i'). {
-                        rewrite H0. rewrite lookup_cons.
-                        auto. }
-                      rewrite <- H6.
-                      eapply H10.
-                      { rewrite length_cons. word. }
-                      { rewrite lookup_cons_Some. right. split.
-                        - word.
-                        - simpl. replace (i' - 0)%nat with i' by word. eassumption.
-                      }
-                      { rewrite lookup_cons_Some. right. split.
-                        - word.
-                        - simpl. replace (i' - 0)%nat with i' by word. eassumption.
-                      }
-                - auto.
-                - auto.
-              } 
-              assert (uint.Z a >? uint.Z a0 = false) by word.
-              rewrite /coq_maxTS. assert (a0 = coq_maxTwoInts a a0). { rewrite /coq_maxTwoInts. rewrite H0. auto. }
-              rewrite <- H1.
-              assert (0%nat < uint.nat i <= length (a :: xs)). {
-                destruct H8; auto. rewrite H3. repeat rewrite length_cons. word. }
-              eapply H10 in H2.
-              { rewrite <- head_lookup in H2. rewrite head_Some in H2. destruct H2 as [l' H2].
-                rewrite H2. f_equal.
-                - eassumption.
-                - eapply IHxs.
-                  + intros.
-                    inversion H3.
-                    destruct H8; auto.
-                    rewrite length_cons in H3.
-                    assert (uint.nat (uint.nat i - 1)%nat = length xs) by word.
-                    eassumption.
-                  + rewrite H. rewrite length_cons in H11. word.
-                  + rewrite length_cons in H9.
-                    assert (length l = (1 + length l')%nat). {  rewrite H2. simpl. auto. }
-                    rewrite H9 in H4. word.
-                  + auto.
-                  + intros.
-                    assert (l !! (S i')%nat = l' !! i').
-                    { rewrite H2. rewrite lookup_cons.
-                      auto. }
-                    rewrite <- H7.
-                    eapply H10.
-                    * rewrite length_cons. word. 
-                    * rewrite lookup_cons_Some. right. split.
-                      { word. }
-                      { simpl. replace (i' - 0)%nat with i' by word. eassumption. }
-                    * rewrite lookup_cons_Some. right. split.
-                        { word. }
-                        { simpl. replace (i' - 0)%nat with i' by word. eassumption. }
-              }
-          - auto.
-          - auto.
-        }
-        rewrite H. iFrame.
-    Qed.
-
-    Lemma wp_read (c: Client.t) (serverId: u64) (n: nat) cv :
-      {{{
-          is_client cv c n ∗
-          ⌜n = uint.nat c.(Client.NumberOfServers)⌝
-      }}}
-        CoqSessionClient.read (client_val cv) (#serverId)
-      {{{
-          msgv, RET (message_val msgv);
-          is_client cv c n ∗
-          is_message msgv (coq_read c serverId) n n 0%nat
-      }}}.
-    Proof. (**
-      rewrite redefine_client_val redefine_message_val. TypeVector.des cv. iIntros "%Φ (H_is_client & ->) HΦ".
-      iDestruct "H_is_client" as "(%H1 & %H2 & H3 & %H4 & H5 & %H6 & %H7)".
-      simplNotation; simpl; subst; rewrite /CoqSessionClient.read.
-      iPoseProof (own_slice_small_sz with "[$H3]") as "%LENGTH1".
-      iPoseProof (own_slice_small_sz with "[$H5]") as "%LENGTH2".
-      wp_pures. wp_apply wp_ref_to. { repeat econstructor; eauto. } iIntros "%reply H_reply".
-      wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 0))) as [ | ] eqn: Heqb.
-      { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_apply (wp_NewSlice). iIntros "%s1 H_s1".
-        iPoseProof (own_slice_sz with "[$H_s1]") as "%LENGTH3". rewrite length_replicate in LENGTH3.
-        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_load.
-        apply bool_decide_eq_true in Heqb.
-        assert (c .(Client.SessionSemantic) = W64 0) as EQ by congruence.
-        replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 0), (#(W64 0), (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 0, W64 0, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
-        iModIntro. simpl. iApply "HΦ".
-        iSplitL "H3 H5".
-        - iFrame. simplNotation; simpl; done.
-        - unfold coq_read. rewrite -> EQ. replace (uint.Z (W64 0)) with 0%Z by word.
-          unfold is_message; iFrame; simplNotation; simpl.
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
-          iSplitL "". { rewrite length_replicate. done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { iApply own_slice_small_nil; eauto. }
-          iSplitL "". { iPureIntro. word. }
-          done.
-      }
-      wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 1))) as [ | ] eqn: Heqb0.
-      { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_apply (wp_NewSlice). iIntros "%s1 H_s1".
-        iPoseProof (own_slice_sz with "[$H_s1]") as "%LENGTH3". rewrite length_replicate in LENGTH3.
-        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_load.
-        apply bool_decide_eq_true in Heqb0.
-        assert (c .(Client.SessionSemantic) = W64 1) as EQ by congruence.
-        replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 0), (#(W64 0), (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 0, W64 0, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
-        iModIntro. simpl. iApply "HΦ".
-        iSplitL "H3 H5".
-        - iFrame. simplNotation; simpl; done.
-        - unfold coq_read. rewrite -> EQ. replace (uint.Z (W64 1)) with 1%Z by word.
-          unfold is_message; iFrame; simplNotation; simpl.
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
-          iSplitL "". { rewrite length_replicate. done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { iApply own_slice_small_nil; eauto. }
-          iSplitL "". { iPureIntro. word. }
-          done.
-      }
-      wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 2))) as [ | ] eqn: Heqb1.
-      { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_apply (wp_NewSlice). iIntros "%s1 H_s1".
-        iPoseProof (own_slice_sz with "[$H_s1]") as "%LENGTH3". rewrite length_replicate in LENGTH3.
-        wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
-        wp_pures. wp_load.
-        apply bool_decide_eq_true in Heqb1.
-        assert (c .(Client.SessionSemantic) = W64 2) as EQ by congruence.
-        replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 0), (#(W64 0), (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 0, W64 0, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
-        iModIntro. simpl. iApply "HΦ".
-        iSplitL "H3 H5".
-        - iFrame. simplNotation; simpl; done.
-        - unfold coq_read. rewrite -> EQ. replace (uint.Z (W64 2)) with 2%Z by word.
-          unfold is_message; iFrame; simplNotation; simpl.
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
-          iSplitL "". { rewrite length_replicate. done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { done. }
-          iSplitL "". { iApply own_slice_small_nil; eauto. }
-          iSplitL "". { iPureIntro. word. }
-          done.
-      }
-      wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 3))) as [ | ] eqn: Heqb2.
-      { admit. }
-      admit.
-    Qed. *) Admitted.
-
-    Lemma wp_write (c: Client.t) (serverId: u64) (value: u64) (n: nat) cv :
-      {{{
-          is_client cv c n ∗
-          ⌜n = uint.nat c.(Client.NumberOfServers)⌝
-      }}}
-        CoqSessionClient.write (client_val cv) (#serverId) (#value)
-      {{{
-          msgv, RET (message_val msgv);
-          is_client cv c n ∗
-          is_message msgv (coq_write c serverId value) n n 0%nat
-      }}}.
-    Proof.
-    Admitted.
-
-    Lemma wp_processRequest (c: Client.t) (requestType: u64) (serverId: u64) (value: u64) (ackMessage: Message.t) (n: nat) cv msgv :
-      {{{
-          is_client cv c n ∗
-          is_message msgv ackMessage n n n ∗
-          ⌜n = uint.nat c.(Client.NumberOfServers)⌝
-      }}}
-        CoqSessionClient.processRequest (client_val cv) (#requestType) (#serverId) (#value) (message_val msgv)
-      {{{
-          cv' msgv', RET (client_val cv', message_val msgv');
-          is_message msgv ackMessage n n n ∗
-          is_client cv' (coq_processRequest c requestType serverId value ackMessage).1 n ∗
-          ∃ n', is_message msgv' (coq_processRequest c requestType serverId value ackMessage).2 n n' 0%nat
-      }}}.
-    Proof.
-    Admitted.
-
-  End heap.
 
 End CoqSessionClient.
 
 Export CoqSessionClient.
+
+Section heap.
+
+  Context `{hG: !heapGS Σ}.
+
+  Lemma wp_maxTwoInts (x: w64) (y: w64) :
+    {{{
+        True
+    }}}
+      CoqSessionClient.maxTwoInts #x #y 
+    {{{
+        r , RET #r;
+        ⌜r = coq_maxTwoInts x y⌝
+    }}}.
+  Proof.
+    iIntros (Φ) "H H1".
+    rewrite /maxTwoInts. wp_pures.
+    wp_if_destruct.
+    - iModIntro. iApply "H1". iPureIntro.
+      unfold coq_maxTwoInts. apply Z.gtb_lt in Heqb.
+      rewrite Heqb. auto.
+    - iModIntro. iApply "H1". iPureIntro.
+      rewrite /coq_maxTwoInts.
+      assert (uint.Z y >= uint.Z x) by word.
+      assert (uint.Z x >? uint.Z y = false) by word.
+      rewrite H0.
+      auto.
+  Qed.
+
+  Lemma wp_maxTS (x: Slice.t) (xs: list w64) (y: Slice.t) (ys: list w64) (d: dfrac) (d': dfrac) :
+    {{{
+        own_slice_small x uint64T d xs ∗
+        own_slice_small y uint64T d' ys ∗
+        ⌜length xs = length ys⌝
+    }}}
+      CoqSessionClient.maxTS x y 
+    {{{
+        (s': Slice.t), RET slice_val s'; 
+        own_slice s' uint64T (DfracOwn 1) (coq_maxTS xs ys) ∗ 
+        own_slice_small x uint64T d xs ∗
+        own_slice_small y uint64T d' ys 
+    }}}.
+  Proof.
+    iIntros (Φ) "(H & H1 & %H3) H2".
+    rewrite /maxTS.
+    iDestruct (own_slice_small_sz with "H") as %Hsz_x.
+    iDestruct (own_slice_small_sz with "H1") as %Hsz_y.
+    wp_pures. wp_apply wp_ref_to; auto.
+    iIntros (index) "index". wp_pures.
+    wp_pures. wp_apply wp_slice_len.
+    wp_apply wp_ref_to; auto.
+    iIntros (len) "len". wp_pures.
+    wp_bind (NewSlice uint64T (slice.len x)).
+    wp_apply wp_slice_len.
+    wp_apply wp_new_slice; auto.
+    iIntros (s') "s'". 
+    wp_apply wp_ref_to; auto.
+    iIntros (slice) "slice". wp_pures.
+    wp_apply (wp_forBreak_cond
+                (λ continue, ∃ (i: w64) (l: list w64),
+                    own_slice_small x uint64T d xs ∗
+                    own_slice_small y uint64T d' ys ∗
+                    own_slice s' uint64T (DfracOwn 1) l ∗ 
+                    index ↦[uint64T] #i ∗
+                    len ↦[uint64T] #(length xs) ∗
+                    slice ↦[slice.T uint64T] s' ∗ 
+                    ⌜continue = false -> uint.nat i = (length xs)⌝ ∗
+                    ⌜length l = length xs⌝ ∗
+                    ⌜forall (i': nat),
+                  i' < uint.nat i <= length xs ->
+                  forall (x y: w64), xs !! i' = Some x ->
+                                      ys !! i' = Some y ->
+                                      l !! i' = Some (coq_maxTwoInts x y)⌝ ∗
+                                      ⌜uint.nat i <= length xs⌝ 
+                )%I
+              with "[] [H H1 index len s' slice]").
+    - iIntros (?). iModIntro. iIntros "H1 H2".
+      iNamed "H1". iDestruct "H1"
+        as "(Hx & Hy & H4 & H5 & H6 & H7 & %H8 & %H9 & %H10 & %H11)".
+      wp_pures. wp_load. wp_load. wp_if_destruct.
+      + wp_pures. wp_load.
+        wp_bind (maxTwoInts _ _)%E.
+        iDestruct "H4" as "[Hs Hsc]".
+        assert (uint.nat i < length xs)%nat by word.
+        rewrite H3 in H. eapply list_lookup_lt in H.
+        destruct H as [x0 H].
+        assert (uint.nat i < length xs)%nat by word.
+        eapply list_lookup_lt in H0.
+        destruct H0 as [y0 H0].
+        wp_apply (wp_SliceGet with "[$Hy]"). { auto. }
+        iIntros "Hy". wp_load. wp_apply (wp_SliceGet with "[$Hx]"). { auto. }
+        iIntros "Hx".
+        wp_apply (wp_maxTwoInts). iIntros (r) "%H12".
+        wp_load. wp_load.
+        wp_apply (wp_SliceSet with "[$Hs]").
+        { iPureIntro. eapply lookup_lt_is_Some_2. word. }
+        iIntros "H11". wp_pures. wp_load. wp_store. iModIntro.
+        iApply "H2". iExists (w64_word_instance.(word.add) i (W64 1)).
+        iExists (<[uint.nat i:=r]> l)%E. iFrame.
+        iSplit. { auto. }
+        iSplit. { iPureIntro. rewrite <- H9. apply length_insert. }
+        iSplit. { iPureIntro. intros. destruct (decide (i' = uint.nat i)).
+                  - rewrite list_lookup_insert_Some.
+                    left.
+                    split. { auto. }
+                    split. { subst. rewrite H4 in H. rewrite H2 in H0. inversion H. inversion H0.
+                            auto. }
+                    word.
+                  - rewrite Z.lt_le_pred in H1.
+                    assert ((Z.pred (uint.nat (w64_word_instance.(word.add) i (W64 1)))) = uint.nat i) by word.
+                    rewrite H5 in H1.
+                    destruct H1. assert(uint.nat i ≠ i') by word.
+                    apply (list_lookup_insert_ne l (uint.nat i) (i') r) in H7.
+                    rewrite H7. eapply H10; try eassumption.
+                    word.
+        }
+        word.
+      + iModIntro. iApply "H2". iExists i. iExists l. iFrame. iPureIntro. split; auto. word.
+    - assert (zero_val uint64T = #(W64 0)). { unfold zero_val. simpl. auto. }
+      rewrite H. iExists (W64 0).
+      iExists (replicate (uint.nat x.(Slice.sz)) (W64 0))%V.
+      iFrame.
+      iSplitL "s'". { rewrite /own_slice. rewrite untype_replicate. iFrame. }
+      iSplitL "len". { rewrite Hsz_x.
+                      assert (#(W64 (uint.nat x.(Slice.sz))) = #x.(Slice.sz)). {
+                        f_equal. rewrite w64_to_nat_id. auto. }
+                      rewrite H0. iFrame. }
+      iPureIntro.
+      split. { intros. inversion H0. }
+      split. { rewrite length_replicate. auto. }
+      split. { intros. word. }
+      word.
+    - iIntros "H". wp_pures. iNamed "H". iDestruct "H" as "(H1 & H3 & H4 & H5 & H6 & H7 & %H8 & %H9 & %H10 & %H11)".
+      wp_load. iModIntro. iApply "H2". iFrame.
+      assert (coq_maxTS xs ys = l). {
+        clear Hsz_x.
+        clear Hsz_y.        
+        generalize dependent ys. generalize dependent l. generalize dependent i.
+        induction xs.
+        + intros. inversion H9. apply nil_length_inv in H0. rewrite H0. auto.
+        + induction ys.
+          * intros. inversion H3.
+          * clear IHys. intros.
+            assert (uint.nat (uint.nat i - 1%nat)%nat = ((uint.nat i) - 1)%nat) by word.
+            destruct (decide (uint.Z a >? uint.Z a0 = true)).
+            { inversion H3.
+              assert (0%nat < uint.nat i <= length (a :: xs)). {
+                destruct H8; auto. rewrite H3. repeat rewrite length_cons. word. }
+              rewrite /coq_maxTS. rewrite /coq_maxTwoInts.
+              rewrite e.
+              eapply H10 in H0.
+              - rewrite <- head_lookup in H0. rewrite head_Some in H0. destruct H0 as [l' H0].
+                rewrite H0. f_equal.
+                + assert (a = coq_maxTwoInts a a0). { rewrite /coq_maxTwoInts. rewrite e. auto. }
+                  eassumption.
+                + eapply IHxs.
+                  * intros. destruct H8; auto.
+                    rewrite length_cons in H3. assert (uint.nat (uint.nat i - 1)%nat = length xs) by word.
+                    eassumption.
+                  * rewrite H. rewrite length_cons in H11. word.
+                  * rewrite length_cons in H9.
+                    assert (length l = (1 + length l')%nat). { rewrite H0. simpl. auto. }
+                    rewrite H9 in H2. word.
+                  * auto.
+                  * intros. assert (l !! (S i')%nat = l' !! i'). {
+                      rewrite H0. rewrite lookup_cons.
+                      auto. }
+                    rewrite <- H6.
+                    eapply H10.
+                    { rewrite length_cons. word. }
+                    { rewrite lookup_cons_Some. right. split.
+                      - word.
+                      - simpl. replace (i' - 0)%nat with i' by word. eassumption.
+                    }
+                    { rewrite lookup_cons_Some. right. split.
+                      - word.
+                      - simpl. replace (i' - 0)%nat with i' by word. eassumption.
+                    }
+              - auto.
+              - auto.
+            } 
+            assert (uint.Z a >? uint.Z a0 = false) by word.
+            rewrite /coq_maxTS. assert (a0 = coq_maxTwoInts a a0). { rewrite /coq_maxTwoInts. rewrite H0. auto. }
+            rewrite <- H1.
+            assert (0%nat < uint.nat i <= length (a :: xs)). {
+              destruct H8; auto. rewrite H3. repeat rewrite length_cons. word. }
+            eapply H10 in H2.
+            { rewrite <- head_lookup in H2. rewrite head_Some in H2. destruct H2 as [l' H2].
+              rewrite H2. f_equal.
+              - eassumption.
+              - eapply IHxs.
+                + intros.
+                  inversion H3.
+                  destruct H8; auto.
+                  rewrite length_cons in H3.
+                  assert (uint.nat (uint.nat i - 1)%nat = length xs) by word.
+                  eassumption.
+                + rewrite H. rewrite length_cons in H11. word.
+                + rewrite length_cons in H9.
+                  assert (length l = (1 + length l')%nat). {  rewrite H2. simpl. auto. }
+                  rewrite H9 in H4. word.
+                + auto.
+                + intros.
+                  assert (l !! (S i')%nat = l' !! i').
+                  { rewrite H2. rewrite lookup_cons.
+                    auto. }
+                  rewrite <- H7.
+                  eapply H10.
+                  * rewrite length_cons. word. 
+                  * rewrite lookup_cons_Some. right. split.
+                    { word. }
+                    { simpl. replace (i' - 0)%nat with i' by word. eassumption. }
+                  * rewrite lookup_cons_Some. right. split.
+                      { word. }
+                      { simpl. replace (i' - 0)%nat with i' by word. eassumption. }
+            }
+        - auto.
+        - auto.
+      }
+      rewrite H. iFrame.
+  Qed.
+
+  Lemma wp_read (c: Client.t) (serverId: u64) (n: nat) cv :
+    {{{
+        is_client cv c n ∗
+        ⌜n = uint.nat c.(Client.NumberOfServers)⌝
+    }}}
+      CoqSessionClient.read (client_val cv) (#serverId)
+    {{{
+        msgv, RET (message_val msgv);
+        is_client cv c n ∗
+        is_message msgv (coq_read c serverId) n n 0%nat
+    }}}.
+  Proof. (**
+    rewrite redefine_client_val redefine_message_val. TypeVector.des cv. iIntros "%Φ (H_is_client & ->) HΦ".
+    iDestruct "H_is_client" as "(%H1 & %H2 & H3 & %H4 & H5 & %H6 & %H7)".
+    simplNotation; simpl; subst; rewrite /CoqSessionClient.read.
+    iPoseProof (own_slice_small_sz with "[$H3]") as "%LENGTH1".
+    iPoseProof (own_slice_small_sz with "[$H5]") as "%LENGTH2".
+    wp_pures. wp_apply wp_ref_to. { repeat econstructor; eauto. } iIntros "%reply H_reply".
+    wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 0))) as [ | ] eqn: Heqb.
+    { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_NewSlice). iIntros "%s1 H_s1".
+      iPoseProof (own_slice_sz with "[$H_s1]") as "%LENGTH3". rewrite length_replicate in LENGTH3.
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_load.
+      apply bool_decide_eq_true in Heqb.
+      assert (c .(Client.SessionSemantic) = W64 0) as EQ by congruence.
+      replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 0), (#(W64 0), (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 0, W64 0, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
+      iModIntro. simpl. iApply "HΦ".
+      iSplitL "H3 H5".
+      - iFrame. simplNotation; simpl; done.
+      - unfold coq_read. rewrite -> EQ. replace (uint.Z (W64 0)) with 0%Z by word.
+        unfold is_message; iFrame; simplNotation; simpl.
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
+        iSplitL "". { rewrite length_replicate. done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iApply own_slice_small_nil; eauto. }
+        iSplitL "". { iPureIntro. word. }
+        done.
+    }
+    wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 1))) as [ | ] eqn: Heqb0.
+    { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_NewSlice). iIntros "%s1 H_s1".
+      iPoseProof (own_slice_sz with "[$H_s1]") as "%LENGTH3". rewrite length_replicate in LENGTH3.
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_load.
+      apply bool_decide_eq_true in Heqb0.
+      assert (c .(Client.SessionSemantic) = W64 1) as EQ by congruence.
+      replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 0), (#(W64 0), (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 0, W64 0, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
+      iModIntro. simpl. iApply "HΦ".
+      iSplitL "H3 H5".
+      - iFrame. simplNotation; simpl; done.
+      - unfold coq_read. rewrite -> EQ. replace (uint.Z (W64 1)) with 1%Z by word.
+        unfold is_message; iFrame; simplNotation; simpl.
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
+        iSplitL "". { rewrite length_replicate. done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iApply own_slice_small_nil; eauto. }
+        iSplitL "". { iPureIntro. word. }
+        done.
+    }
+    wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 2))) as [ | ] eqn: Heqb1.
+    { wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_apply (wp_NewSlice). iIntros "%s1 H_s1".
+      iPoseProof (own_slice_sz with "[$H_s1]") as "%LENGTH3". rewrite length_replicate in LENGTH3.
+      wp_pures. wp_apply (wp_storeField_struct with "[H_reply]"). { repeat econstructor; eauto. } { iFrame. } iIntros "H_reply".
+      wp_pures. wp_load.
+      apply bool_decide_eq_true in Heqb1.
+      assert (c .(Client.SessionSemantic) = W64 2) as EQ by congruence.
+      replace (Φ (#(W64 0), (#c .(Client.Id), (#serverId, (#(W64 0), (#(W64 0), (s1, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T (slice.T uint64T * (uint64T * unitT)%ht)), (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val uint64T, (zero_val (slice.T uint64T), (zero_val uint64T, (zero_val uint64T, #()))))))))))))))))))%V) with (Φ (message_val (W64 0, c.(Client.Id), serverId, W64 0, W64 0, s1, W64 0, W64 0, Slice.nil, W64 0, W64 0, W64 0, W64 0, W64 0, W64 0, Slice.nil, W64 0, W64 0)%core)) by reflexivity.
+      iModIntro. simpl. iApply "HΦ".
+      iSplitL "H3 H5".
+      - iFrame. simplNotation; simpl; done.
+      - unfold coq_read. rewrite -> EQ. replace (uint.Z (W64 2)) with 2%Z by word.
+        unfold is_message; iFrame; simplNotation; simpl.
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "H_s1". { iApply (own_slice_to_small with "[$H_s1]"). }
+        iSplitL "". { rewrite length_replicate. done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iExists []. simpl; iSplitR ""; try done. iApply (own_slice_nil); eauto. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { done. }
+        iSplitL "". { iApply own_slice_small_nil; eauto. }
+        iSplitL "". { iPureIntro. word. }
+        done.
+    }
+    wp_pures. destruct (bool_decide (#c .(Client.SessionSemantic) = #(W64 3))) as [ | ] eqn: Heqb2.
+    { admit. }
+    admit.
+  Qed. *) Admitted.
+
+  Lemma wp_write (c: Client.t) (serverId: u64) (value: u64) (n: nat) cv :
+    {{{
+        is_client cv c n ∗
+        ⌜n = uint.nat c.(Client.NumberOfServers)⌝
+    }}}
+      CoqSessionClient.write (client_val cv) (#serverId) (#value)
+    {{{
+        msgv, RET (message_val msgv);
+        is_client cv c n ∗
+        is_message msgv (coq_write c serverId value) n n 0%nat
+    }}}.
+  Proof.
+  Admitted.
+
+  Lemma wp_processRequest (c: Client.t) (requestType: u64) (serverId: u64) (value: u64) (ackMessage: Message.t) (n: nat) cv msgv :
+    {{{
+        is_client cv c n ∗
+        is_message msgv ackMessage n n n ∗
+        ⌜n = uint.nat c.(Client.NumberOfServers)⌝
+    }}}
+      CoqSessionClient.processRequest (client_val cv) (#requestType) (#serverId) (#value) (message_val msgv)
+    {{{
+        cv' msgv', RET (client_val cv', message_val msgv');
+        is_client cv' (coq_processRequest c requestType serverId value ackMessage).1 n ∗
+        ∃ n', is_message msgv' (coq_processRequest c requestType serverId value ackMessage).2 n n' 0%nat ∗
+        is_message msgv ackMessage n n n ∗
+        ⌜n = uint.nat (coq_processRequest c requestType serverId value ackMessage).1.(Client.NumberOfServers)⌝
+    }}}.
+  Proof.
+  Admitted.
+
+End heap.

--- a/src/program_proof/session/definitions.v
+++ b/src/program_proof/session/definitions.v
@@ -1,5 +1,4 @@
 From Perennial.program_proof.session Require Export session_prelude.
-From Goose.github_com.session Require Export client. (* NOTE: I've included this in session_prelude however I'm not sure why it doesn't work without this line *)
 
 Module Operation.
 
@@ -72,7 +71,6 @@ Module Client.
       }.
   
 End Client.
-       
 
 Section heap.
   Context `{hG: !heapGS Σ}.
@@ -323,7 +321,6 @@ Section heap.
     operation_slice sv!(6) s.(Server.PendingOperations) len_po ∗
     own_slice_small sv!(7) uint64T (DfracOwn 1) s.(Server.GossipAcknowledgements) ∗
     ⌜len_ga = length s.(Server.GossipAcknowledgements)⌝.
-
 
   Definition is_server sv s n len_vc len_op len_mo len_po len_ga : iProp Σ :=
     is_server' sv s n len_vc len_op len_mo len_po len_ga true.

--- a/src/program_proof/session/definitions.v
+++ b/src/program_proof/session/definitions.v
@@ -381,10 +381,10 @@ Section heap.
   #[global] Instance client_into_val_for_type : IntoValForType (u64*u64*Slice.t*Slice.t*u64) (struct.t client.Client).
   Proof. constructor; auto. cbn. split; auto. Qed.
 
-  Definition is_client (cv: tuple_of [u64,u64,Slice.t,Slice.t,u64])
-    (c: Client.t) (n: nat) : iProp Σ :=
+  Definition is_client (cv: tuple_of [u64,u64,Slice.t,Slice.t,u64]) (c: Client.t) (n: nat) : iProp Σ :=
     ⌜cv!(0) = c.(Client.Id)⌝ ∗
     ⌜cv!(1) = c.(Client.NumberOfServers)⌝ ∗
+    ⌜n = uint.nat c.(Client.NumberOfServers)⌝ ∗
     own_slice_small cv!(2) uint64T (DfracOwn 1) c.(Client.WriteVersionVector) ∗
     ⌜n = length c.(Client.WriteVersionVector)⌝ ∗
     own_slice_small cv!(3) uint64T (DfracOwn 1) c.(Client.ReadVersionVector) ∗

--- a/src/program_proof/session/gossip.v
+++ b/src/program_proof/session/gossip.v
@@ -241,7 +241,7 @@ Section heap.
         is_server' sv s n len_vc len_op len_mo len_po len_ga OWN_UnsatisfiedRequests ∗ 
         is_message msgv msg n len_c2s len_s2c
     }}}
-      acknowledgeGossip (server_val sv) (message_val msgv)
+      CoqSessionServer.acknowledgeGossip (server_val sv) (message_val msgv)
     {{{
         RET (server_val sv);
         is_server' sv (coq_acknowledgeGossip s msg) n len_vc len_op len_mo len_po len_ga OWN_UnsatisfiedRequests ∗
@@ -291,7 +291,7 @@ Section heap.
     {{{
         is_server' sv s n len_vc len_op len_mo len_po len_ga OWN_UnsatisfiedRequests
     }}}
-      getGossipOperations (server_val sv) (#serverId)
+      CoqSessionServer.getGossipOperations (server_val sv) (#serverId)
     {{{
         ns, RET (slice_val ns);
         operation_slice ns (coq_getGossipOperations s serverId) len_mo ∗

--- a/src/program_proof/session/processClientRequest.v
+++ b/src/program_proof/session/processClientRequest.v
@@ -10,7 +10,7 @@ Section heap.
         operation_slice s l n ∗
         ⌜(uint.nat index < length l)%nat⌝
     }}}
-      deleteAtIndexOperation s #index
+      CoqSessionServer.deleteAtIndexOperation s #index
     {{{
         ns, RET (slice_val ns);
         operation_slice ns (coq_deleteAtIndexOperation l (uint.nat index)) n ∗
@@ -88,7 +88,7 @@ Section heap.
         message_slice s l n len_c2s ∗
         ⌜(uint.nat index < length l)%nat⌝
     }}}
-      deleteAtIndexMessage s #index
+      CoqSessionServer.deleteAtIndexMessage s #index
     {{{
         ns, RET (slice_val ns);
         message_slice ns (coq_deleteAtIndexMessage l (uint.nat index)) n len_c2s ∗
@@ -146,7 +146,7 @@ Section heap.
     {{{
         operation_slice s l n
     }}}
-      getDataFromOperationLog s
+      CoqSessionServer.getDataFromOperationLog s
     {{{
         r, RET #r;
         ⌜r = coq_getDataFromOperationLog l⌝ ∗
@@ -205,7 +205,7 @@ Section heap.
         is_operation opv1 o1 n ∗
         is_operation opv2 o2 n
     }}}
-      equalOperations (operation_val opv1) (operation_val opv2)
+      CoqSessionServer.equalOperations (operation_val opv1) (operation_val opv2)
     {{{
         r, RET #r;
         ⌜r = coq_equalOperations o1 o2⌝ ∗
@@ -236,7 +236,7 @@ Section heap.
         operation_slice s2 l2 n ∗
         ⌜is_sorted l1⌝
     }}}
-      mergeOperations s1 s2 
+      CoqSessionServer.mergeOperations s1 s2 
     {{{
         ns, RET (slice_val ns);
         ∃ nxs, operation_slice ns nxs n ∗

--- a/src/program_proof/session/processRequest.v
+++ b/src/program_proof/session/processRequest.v
@@ -11,7 +11,7 @@ Section heap.
         is_message msgv msg n m len_s2c ∗
         ⌜SERVER_INVARIANT s⌝
     }}}
-      processClientRequest (server_val sv) (message_val msgv)
+      CoqSessionServer.processClientRequest (server_val sv) (message_val msgv)
     {{{
         b ns nm, RET (#b, server_val ns, message_val nm);
         ⌜b = (coq_processClientRequest s msg).1.1⌝ ∗
@@ -155,7 +155,7 @@ Section heap.
         is_message msgv msg n n len_s2c ∗
         ⌜SERVER_INVARIANT s⌝
     }}}
-      server.processRequest (server_val sv) (message_val msgv)
+      CoqSessionServer.processRequest (server_val sv) (message_val msgv)
     {{{
         ns nms, RET (server_val ns, slice_val nms);
         is_server ns (coq_processRequest s msg).1 n n n n n len_ga ∗
@@ -167,7 +167,7 @@ Section heap.
     unfold is_server. rewrite redefine_server_val redefine_message_val. TypeVector.des sv. TypeVector.des msgv. iIntros "%Φ (H_server & H_message & %H_precondition) HΦ".
     iDestruct "H_server" as "(%H1 & %H2 & H3 & H4 & %H5 & H6 & H7 & H8 & H9 & %H10)".
     iDestruct "H_message" as "(%H11 & %H12 & %H13 & %H14 & %H15 & H16 & %H17 & %H18 & %H19 & H20 & %H21 & %H22 & %H23 & %H24 & %H25 & %H26 & H27 & %H28 & %H29 & %H30)".
-    destruct H_precondition as [? ? ? ?]; simplNotation; subst; rewrite /server.processRequest.
+    destruct H_precondition as [? ? ? ?]; simplNotation; subst; rewrite /CoqSessionServer.processRequest.
     wp_pure. wp_apply wp_NewSlice. simpl. rewrite rewrite_nil; cycle 1. { word. } iIntros "%s1 H_s1".
     wp_pures. wp_apply wp_ref_to. { repeat econstructor; eauto. } iIntros "%outGoingRequests H_outGoingRequests".
     wp_pures. wp_apply wp_ref_to. { repeat econstructor; eauto. } iIntros "%server H_server".

--- a/src/program_proof/session/session_prelude.v
+++ b/src/program_proof/session/session_prelude.v
@@ -217,36 +217,6 @@ Module SessionPrelude.
     - intros NE. word.
   Qed.
 
-  #[global, program]
-  Instance hsEq_w64 : hsEq w64 (well_formed := fun _ => True) :=
-    { eqProp := @eq w64
-    ; eqb x y := (uint.Z x =? uint.Z y)%Z
-    ; eqProp_reflexivity := _
-    ; eqProp_symmetry := _
-    ; eqProp_transitivity := _
-    ; eqb_eq := _
-    ; eqb_neq := _
-    }.
-  Next Obligation.
-    reflexivity; eauto.
-  Qed.
-  Next Obligation.
-    symmetry; eauto.
-  Qed.
-  Next Obligation.
-    etransitivity; eauto.
-  Qed.
-  Next Obligation.
-    simpl. rewrite Z.eqb_eq. split.
-    - intros EQ. word.
-    - congruence.
-  Qed.
-  Next Obligation.
-    simpl. rewrite Z.eqb_neq. split.
-    - congruence.
-    - intros NE. word.
-  Qed.
-
   (** End basic_instances_of_hsEq. *)
 
   Class hsOrd (A : Type) {well_formed : A -> Prop} {hsEq : hsEq A (well_formed := well_formed)} : Type :=
@@ -386,36 +356,6 @@ Module SessionPrelude.
 
   #[global, program]
   Instance hsOrd_u64 : hsOrd u64 :=
-    { ltProp x y := (uint.Z x < uint.Z y)%Z
-    ; ltb x y := (uint.Z y >? uint.Z x)%Z
-    ; ltProp_irreflexivity := _
-    ; ltProp_transitivity := _
-    ; ltProp_trichotomy := _
-    ; ltb_lt x y := _
-    ; ltb_nlt x y := _
-    }.
-  Next Obligation.
-    simpl. do 2 red in x_eq_y. word.
-  Qed.
-  Next Obligation.
-    simpl in *. word.
-  Qed.
-  Next Obligation.
-    simpl in *.
-    assert (uint.Z x < uint.Z y \/ uint.Z x = uint.Z y \/ uint.Z x > uint.Z y) as [LT | [EQ | GT]] by word.
-    - left. word.
-    - right. left. word. 
-    - right. right. word.
-  Qed.
-  Next Obligation.
-    rewrite Z.gtb_gt. word.
-  Qed.
-  Next Obligation.
-    simpl. rewrite Z.gtb_ltb Z.ltb_ge. word.
-  Qed.
-
-  #[global, program]
-  Instance hsOrd_w64 : hsOrd w64 :=
     { ltProp x y := (uint.Z x < uint.Z y)%Z
     ; ltb x y := (uint.Z y >? uint.Z x)%Z
     ; ltProp_irreflexivity := _

--- a/src/program_proof/session/sort.v
+++ b/src/program_proof/session/sort.v
@@ -132,7 +132,7 @@ Section heap.
           is_operation opv needle n ∗
           ⌜is_sorted l⌝
     }}}
-      binarySearch s (operation_val opv)
+      CoqSessionServer.binarySearch s (operation_val opv)
       {{{ (i: u64) , RET #i ;
           operation_slice s l n ∗
           is_operation opv needle n ∗
@@ -383,7 +383,7 @@ Section heap.
           is_operation opv v n ∗
           ⌜is_sorted l⌝ 
     }}}
-      sortedInsert s (operation_val opv)
+      CoqSessionServer.sortedInsert s (operation_val opv)
       {{{ (ns: Slice.t), RET slice_val (ns);
           ∃ nxs, operation_slice ns nxs n %I ∗
                  ⌜nxs = coq_sortedInsert l v⌝
@@ -726,7 +726,7 @@ Section heap.
         is_operation o v n ∗
         ⌜is_sorted l⌝ 
     }}}
-      sortedInsert (slice_val s) (operation_val o)
+      CoqSessionServer.sortedInsert (slice_val s) (operation_val o)
     {{{
         ns, RET (slice_val ns);
         operation_slice ns (coq_sortedInsert l v) n ∗

--- a/src/program_proof/session/versionVector.v
+++ b/src/program_proof/session/versionVector.v
@@ -10,7 +10,7 @@ Section heap.
           own_slice_small y uint64T d ys ∗
           ⌜length xs = length ys⌝ 
     }}}
-      compareVersionVector x y 
+      CoqSessionServer.compareVersionVector x y 
       {{{
             r , RET #r;
             ⌜r = coq_compareVersionVector xs ys⌝ ∗
@@ -423,7 +423,7 @@ Section heap.
     {{{
           True
     }}}
-      maxTwoInts #x #y 
+      CoqSessionServer.maxTwoInts #x #y 
       {{{
             r , RET #r;
             ⌜r = coq_maxTwoInts x y⌝
@@ -449,7 +449,7 @@ Section heap.
             own_slice_small y uint64T d' ys ∗
             ⌜length xs = length ys⌝
     }}}
-      maxTS x y 
+      CoqSessionServer.maxTS x y 
       {{{
             (s': Slice.t), RET slice_val s'; 
             own_slice s' uint64T (DfracOwn 1) (coq_maxTS xs ys) ∗ 
@@ -642,7 +642,7 @@ Section heap.
             own_slice_small y uint64T d ys ∗
             ⌜length xs = length ys⌝ 
       }}}
-        equalSlices x y 
+        CoqSessionServer.equalSlices x y 
         {{{
               r , RET #r;
               ⌜r = coq_equalSlices xs ys⌝ ∗ 
@@ -857,7 +857,7 @@ Section heap.
           own_slice_small y uint64T dq_y ys ∗
           ⌜length xs = length ys⌝
     }}}
-      oneOffVersionVector x y
+      CoqSessionServer.oneOffVersionVector x y
       {{{ (b: bool) , RET #b ;
           ⌜b = coq_oneOffVersionVector xs ys⌝ ∗
           own_slice_small x uint64T dq_x xs ∗


### PR DESCRIPTION
```coq
  Definition is_client (cv: tuple_of [u64,u64,Slice.t,Slice.t,u64]) (c: Client.t) (n: nat) : iProp Σ :=
    ⌜cv!(0) = c.(Client.Id)⌝ ∗
    ⌜cv!(1) = c.(Client.NumberOfServers)⌝ ∗
    ⌜n = uint.nat c.(Client.NumberOfServers)⌝ ∗
    own_slice_small cv!(2) uint64T (DfracOwn 1) c.(Client.WriteVersionVector) ∗
    ⌜n = length c.(Client.WriteVersionVector)⌝ ∗
    own_slice_small cv!(3) uint64T (DfracOwn 1) c.(Client.ReadVersionVector) ∗
    ⌜n = length c.(Client.ReadVersionVector)⌝ ∗
    ⌜cv!(4) = c.(Client.SessionSemantic)⌝.
    
  Record CLIENT_INVARIANT (c: Client.t) : Prop :=
    CLIENT_INVARIANT_INTRO
    { SessionSemantic_ge_0: (uint.Z c.(Client.SessionSemantic) >= 0)%Z
    ; SessionSemantic_le_5: (uint.Z c.(Client.SessionSemantic) <= 5)%Z
    }.
 
  Lemma wp_read (c: Client.t) (serverId: u64) (n: nat) cv :
    {{{
        is_client cv c n ∗
        ⌜CLIENT_INVARIANT c⌝
    }}}
      CoqSessionClient.read (client_val cv) (#serverId)
    {{{
        msgv, RET (message_val msgv);
        is_client cv c n ∗
        is_message msgv (coq_read c serverId) n n 0%nat
    }}}.

  Lemma wp_write (c: Client.t) (serverId: u64) (value: u64) (n: nat) cv :
    {{{
        is_client cv c n ∗
        ⌜CLIENT_INVARIANT c⌝
    }}}
      CoqSessionClient.write (client_val cv) (#serverId) (#value)
    {{{
        msgv, RET (message_val msgv);
        is_client cv c n ∗
        is_message msgv (coq_write c serverId value) n n 0%nat
    }}}.

  Lemma wp_processRequest (c: Client.t) (requestType: u64) (serverId: u64) (value: u64) (ackMessage: Message.t) (n: nat) cv msgv :
    {{{
        is_client cv c n ∗
        is_message msgv ackMessage n n n ∗
        ⌜CLIENT_INVARIANT c⌝
    }}}
      CoqSessionClient.processRequest (client_val cv) (#requestType) (#serverId) (#value) (message_val msgv)
    {{{
        cv' msgv', RET (client_val cv', message_val msgv');
        is_client cv' (coq_processRequest c requestType serverId value ackMessage).1 n ∗
        is_message msgv' (coq_processRequest c requestType serverId value ackMessage).2 n (if (uint.Z requestType =? 0)%Z || (uint.Z requestType =? 1)%Z then n else 0%nat) 0%nat ∗
        is_message msgv ackMessage n n n ∗
        ⌜CLIENT_INVARIANT (coq_processRequest c requestType serverId value ackMessage).1⌝
    }}}.
```